### PR TITLE
#3 React Query Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.3.8",
         "@react-oauth/google": "^0.13.4",
         "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "date-fns": "^4.1.0",
         "gapi-script": "^1.2.0",
         "idb": "^8.0.3",
@@ -3275,6 +3276,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.90.21",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
@@ -3288,6 +3299,23 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
+      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.93.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.20",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vite-plugin-pwa": "^1.2.0"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.91.3",
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, lazy, Suspense } from 'react';
 import {
   ThemeProvider,
   CssBaseline,
@@ -40,6 +40,13 @@ import { queryClient } from './lib/queryClient';
 import { useEntries, useAddEntry, useUpdateEntry, useDeleteEntry } from './hooks/useEntries';
 import { isIndexedDBSupported } from './services/db';
 import { migrateFromLocalStorage, createLocalStorageBackup } from './services/migration';
+
+// Lazy load React Query DevTools only in development
+const ReactQueryDevtools = lazy(() =>
+  import('@tanstack/react-query-devtools').then((mod) => ({
+    default: mod.ReactQueryDevtools,
+  }))
+);
 
 function AppContent() {
   const { t, direction } = useLanguage();
@@ -349,6 +356,11 @@ export default function App() {
       <LanguageProvider>
         <AppContent />
       </LanguageProvider>
+      {import.meta.env.DEV && (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+        </Suspense>
+      )}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Add React Query DevTools for development debugging
- Lazy-load DevTools to minimize production impact
- DevTools only render in development mode (`import.meta.env.DEV`)

## Changes
- `package.json`: Added `@tanstack/react-query-devtools` as devDependency
- `src/App.jsx`: Added lazy-loaded DevTools component with Suspense boundary

## Note
React Query core integration (QueryClient, hooks, optimistic updates) was already completed in PR #27 (IndexedDB Migration). This PR adds the DevTools for development.

## Acceptance Criteria (from Issue #3)
- [x] QueryClient configured with sensible defaults
- [x] All data operations use React Query hooks
- [x] Optimistic updates for better UX
- [x] Query invalidation works correctly
- [x] DevTools available in development

## Test Plan
- [x] All 201 tests pass
- [x] Lint passes with no errors
- [x] DevTools appear in dev mode (bottom-right corner)
- [x] DevTools do NOT appear in production build

Closes #3