### PR TITLE
#58 Enable Firestore delete rules for GDPR erasure

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,8 +76,8 @@ service cloud.firestore {
                     && request.resource.data.userId == request.auth.uid
                     && !resource.data.completed;
 
-      // Users cannot delete migration status (audit trail)
-      allow delete: if false;
+      // Users can delete migration status (required for GDPR Article 17 erasure)
+      allow delete: if isOwner(userId);
     }
 
     // Migration history subcollection
@@ -92,7 +92,8 @@ service cloud.firestore {
 
       // History entries are immutable (audit trail)
       allow update: if false;
-      allow delete: if false;
+      // Users can delete their own history entries (required for GDPR Article 17 erasure)
+      allow delete: if isOwner(userId);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Enable `allow delete: if isOwner(userId)` on migration metadata and history collections
- Required for GDPR Article 17 (right to erasure) implementation in Issue #53
- Entries and profile collections already had correct delete rules

## Changes
- `firestore.rules` line 80: `allow delete: if false` → `allow delete: if isOwner(userId)`
- `firestore.rules` line 95: `allow delete: if false` → `allow delete: if isOwner(userId)`

## Test Plan
- Firebase rules validation: PASSED
- All 1003 existing tests: PASSED (0 regressions)
- Lint: PASSED

Closes #58