### PR TITLE
#64 Write GDPR unit tests and final validation

### DIFF
--- a/src/components/DataManagementDialog.test.jsx
+++ b/src/components/DataManagementDialog.test.jsx
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DataManagementDialog from './DataManagementDialog';
+
+vi.mock('../hooks/useGdprActions');
+vi.mock('../contexts/useLanguage', () => ({
+  useLanguage: vi.fn(),
+}));
+
+import { useGdprActions } from '../hooks/useGdprActions';
+import { useLanguage } from '../contexts/useLanguage';
+
+const defaultTranslations = {
+  dataManagement: {
+    exportMyData: 'Export my data',
+    deleteCloudData: 'Delete cloud data',
+    close: 'Close',
+    exportingProgress: 'Exporting...',
+    exportSuccess: 'Export Complete!',
+    exportDescription: 'Your data has been downloaded.',
+    exportTitle: 'Export Your Data',
+    deleteTitle: 'Delete Cloud Data',
+    deleteWarning: 'This will permanently delete all your data from the cloud.',
+    deleteConfirmation: 'This action cannot be undone.',
+    iUnderstandCheckbox: 'I understand this action cannot be undone',
+    deletingProgress: 'Deleting...',
+    deleteSuccess: 'Cloud Data Deleted',
+    deleteSuccessMessage: 'Your cloud data has been permanently deleted.',
+    exportErrorMessage: 'Could not export your data. Please try again.',
+    deleteErrorMessage: 'Could not delete your cloud data. Please try again.',
+    exportError: 'Export Failed',
+    deleteError: 'Delete Failed',
+  },
+  settings: 'Data Management',
+  tryAgain: 'Try Again',
+};
+
+function createDefaultHookReturn(overrides = {}) {
+  return {
+    handleExport: vi.fn(),
+    isExporting: false,
+    exportSuccess: false,
+    exportError: null,
+    resetExport: vi.fn(),
+    handleDelete: vi.fn(),
+    isDeleting: false,
+    deleteSuccess: false,
+    deleteError: null,
+    resetDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderDialog(props = {}, hookOverrides = {}, languageOverrides = {}) {
+  useGdprActions.mockReturnValue(createDefaultHookReturn(hookOverrides));
+  useLanguage.mockReturnValue({
+    t: { ...defaultTranslations, ...(languageOverrides.t || {}) },
+    direction: languageOverrides.direction || 'ltr',
+  });
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DataManagementDialog open={true} onClose={vi.fn()} {...props} />
+    </QueryClientProvider>
+  );
+}
+
+describe('DataManagementDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('idle state', () => {
+    it('should render with two action buttons', () => {
+      renderDialog();
+
+      expect(screen.getByText('Export my data')).toBeInTheDocument();
+      expect(screen.getByText('Delete cloud data')).toBeInTheDocument();
+    });
+
+    it('should render dialog title as Data Management', () => {
+      renderDialog();
+
+      expect(screen.getByText('Data Management')).toBeInTheDocument();
+    });
+
+    it('should render close button', () => {
+      renderDialog();
+
+      expect(screen.getByText('Close')).toBeInTheDocument();
+    });
+  });
+
+  describe('open/close behavior', () => {
+    it('should not render dialog content when open is false', () => {
+      renderDialog({ open: false });
+
+      expect(screen.queryByText('Export my data')).not.toBeInTheDocument();
+    });
+
+    it('should call onClose when close button clicked in idle state', () => {
+      const onClose = vi.fn();
+      const hookReturn = createDefaultHookReturn();
+      useGdprActions.mockReturnValue(hookReturn);
+      useLanguage.mockReturnValue({ t: defaultTranslations, direction: 'ltr' });
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DataManagementDialog open={true} onClose={onClose} />
+        </QueryClientProvider>
+      );
+
+      fireEvent.click(screen.getByText('Close'));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should call resetExport and resetDelete on close', () => {
+      const onClose = vi.fn();
+      const resetExport = vi.fn();
+      const resetDelete = vi.fn();
+
+      renderDialog({ onClose }, { resetExport, resetDelete });
+
+      fireEvent.click(screen.getByText('Close'));
+
+      expect(resetExport).toHaveBeenCalled();
+      expect(resetDelete).toHaveBeenCalled();
+    });
+  });
+
+  describe('export flow', () => {
+    it('should call handleExport when export button is clicked', () => {
+      const handleExport = vi.fn();
+      renderDialog({}, { handleExport });
+
+      fireEvent.click(screen.getByText('Export my data'));
+
+      expect(handleExport).toHaveBeenCalled();
+    });
+
+    it('should show CircularProgress when isExporting is true', () => {
+      renderDialog({}, { isExporting: true });
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByText('Exporting...')).toBeInTheDocument();
+    });
+
+    it('should show export title when exporting', () => {
+      renderDialog({}, { isExporting: true });
+
+      expect(screen.getByText('Export Your Data')).toBeInTheDocument();
+    });
+
+    it('should show export success state when exportSuccess is true', () => {
+      renderDialog({}, { exportSuccess: true });
+
+      expect(screen.getByText('Export Complete!')).toBeInTheDocument();
+      expect(screen.getByText('Your data has been downloaded.')).toBeInTheDocument();
+    });
+  });
+
+  describe('delete flow', () => {
+    it('should show delete confirmation when delete is clicked', () => {
+      renderDialog();
+
+      fireEvent.click(screen.getByText('Delete cloud data'));
+
+      expect(screen.getByText('This will permanently delete all your data from the cloud.')).toBeInTheDocument();
+      expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+    });
+
+    it('should show checkbox in delete confirmation', () => {
+      renderDialog();
+
+      fireEvent.click(screen.getByText('Delete cloud data'));
+
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+      expect(screen.getByText('I understand this action cannot be undone')).toBeInTheDocument();
+    });
+
+    it('should have delete button disabled until checkbox is checked', () => {
+      renderDialog();
+
+      fireEvent.click(screen.getByText('Delete cloud data'));
+
+      const deleteButtons = screen.getAllByText('Delete cloud data');
+      const confirmDeleteButton = deleteButtons.find((btn) =>
+        btn.closest('button')?.hasAttribute('disabled') || btn.closest('button[disabled]')
+      );
+      expect(confirmDeleteButton?.closest('button')).toBeDisabled();
+    });
+
+    it('should enable delete button after checkbox is checked', () => {
+      renderDialog();
+
+      fireEvent.click(screen.getByText('Delete cloud data'));
+
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+
+      const deleteButtons = screen.getAllByText('Delete cloud data');
+      const confirmBtn = deleteButtons.find(
+        (btn) => btn.closest('button')?.getAttribute('disabled') === null
+      );
+      expect(confirmBtn).toBeTruthy();
+    });
+
+    it('should call handleDelete when confirmed', () => {
+      const handleDelete = vi.fn();
+      renderDialog({}, { handleDelete });
+
+      fireEvent.click(screen.getByText('Delete cloud data'));
+
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+
+      const deleteButtons = screen.getAllByText('Delete cloud data');
+      const confirmBtn = deleteButtons.find(
+        (btn) => !btn.closest('button')?.disabled
+      );
+      fireEvent.click(confirmBtn);
+
+      expect(handleDelete).toHaveBeenCalled();
+    });
+
+    it('should show LinearProgress when isDeleting is true', () => {
+      renderDialog({}, { isDeleting: true });
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByText('Deleting...')).toBeInTheDocument();
+    });
+
+    it('should show delete title when deleting', () => {
+      renderDialog({}, { isDeleting: true });
+
+      expect(screen.getByText('Delete Cloud Data')).toBeInTheDocument();
+    });
+
+    it('should show delete success state when deleteSuccess is true', () => {
+      renderDialog({}, { deleteSuccess: true });
+
+      expect(screen.getByText('Cloud Data Deleted')).toBeInTheDocument();
+      expect(screen.getByText('Your cloud data has been permanently deleted.')).toBeInTheDocument();
+    });
+
+    it('should start in delete confirmation when initialAction is delete', () => {
+      renderDialog({ initialAction: 'delete' });
+
+      expect(screen.getByText('This will permanently delete all your data from the cloud.')).toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('error states', () => {
+    it('should show export error message when exportError is set', () => {
+      renderDialog({}, { exportError: new Error('Export failed') });
+
+      expect(screen.getByText('Could not export your data. Please try again.')).toBeInTheDocument();
+    });
+
+    it('should show export error title when exportError is set', () => {
+      renderDialog({}, { exportError: new Error('fail') });
+
+      expect(screen.getByText('Export Failed')).toBeInTheDocument();
+    });
+
+    it('should show delete error message when deleteError is set', () => {
+      renderDialog({}, { deleteError: new Error('Delete failed') });
+
+      expect(screen.getByText('Could not delete your cloud data. Please try again.')).toBeInTheDocument();
+    });
+
+    it('should show delete error title when deleteError is set', () => {
+      renderDialog({}, { deleteError: new Error('fail') });
+
+      expect(screen.getByText('Delete Failed')).toBeInTheDocument();
+    });
+
+    it('should show Try Again button on error', () => {
+      renderDialog({}, { exportError: new Error('fail') });
+
+      expect(screen.getByText('Try Again')).toBeInTheDocument();
+    });
+
+    it('should show Close button on error', () => {
+      renderDialog({}, { exportError: new Error('fail') });
+
+      expect(screen.getByText('Close')).toBeInTheDocument();
+    });
+  });
+
+  describe('operation in progress protection', () => {
+    it('should not close dialog when exporting', () => {
+      const onClose = vi.fn();
+      const hookReturn = createDefaultHookReturn({ isExporting: true });
+      useGdprActions.mockReturnValue(hookReturn);
+      useLanguage.mockReturnValue({ t: defaultTranslations, direction: 'ltr' });
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DataManagementDialog open={true} onClose={onClose} />
+        </QueryClientProvider>
+      );
+
+      expect(screen.queryByText('Close')).not.toBeInTheDocument();
+    });
+
+    it('should not close dialog when deleting', () => {
+      const onClose = vi.fn();
+      const hookReturn = createDefaultHookReturn({ isDeleting: true });
+      useGdprActions.mockReturnValue(hookReturn);
+      useLanguage.mockReturnValue({ t: defaultTranslations, direction: 'ltr' });
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DataManagementDialog open={true} onClose={onClose} />
+        </QueryClientProvider>
+      );
+
+      expect(screen.queryByText('Close')).not.toBeInTheDocument();
+    });
+
+    it('should disable escape key during exporting via disableEscapeKeyDown', () => {
+      renderDialog({}, { isExporting: true });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+    });
+
+    it('should disable escape key during deleting via disableEscapeKeyDown', () => {
+      renderDialog({}, { isDeleting: true });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+    });
+  });
+
+  describe('RTL support', () => {
+    it('should render with rtl direction when language is Hebrew', () => {
+      renderDialog({}, {}, { direction: 'rtl' });
+
+      const dialog = screen.getByRole('dialog');
+      const dirElement = dialog.closest('[dir="rtl"]') || dialog.querySelector('[dir="rtl"]');
+      expect(dirElement || dialog.parentElement.closest('[dir="rtl"]')).toBeTruthy();
+    });
+
+    it('should render with ltr direction when language is English', () => {
+      renderDialog({}, {}, { direction: 'ltr' });
+
+      const dialog = screen.getByRole('dialog');
+      const dirElement = dialog.closest('[dir="ltr"]') || dialog.querySelector('[dir="ltr"]');
+      expect(dirElement || dialog.parentElement.closest('[dir="ltr"]')).toBeTruthy();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have aria-labelledby on dialog', () => {
+      renderDialog();
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'data-management-title');
+    });
+
+    it('should have aria-describedby on dialog', () => {
+      renderDialog();
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-describedby', 'data-management-content');
+    });
+
+    it('should have aria-live on exporting progress text', () => {
+      renderDialog({}, { isExporting: true });
+
+      const progressText = screen.getByText('Exporting...');
+      expect(progressText).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should have aria-live on deleting progress text', () => {
+      renderDialog({}, { isDeleting: true });
+
+      const progressText = screen.getByText('Deleting...');
+      expect(progressText).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
+  describe('memoization', () => {
+    it('should be exported as a memo component', async () => {
+      const mod = await import('./DataManagementDialog');
+      expect(mod.default.$$typeof).toBe(Symbol.for('react.memo'));
+    });
+  });
+});

--- a/src/components/UserProfile.test.jsx
+++ b/src/components/UserProfile.test.jsx
@@ -19,6 +19,24 @@ vi.mock('../services/auth', () => ({
 // Mock the useMigration hook
 vi.mock('../hooks/useMigration', () => ({
   useMigration: vi.fn(),
+  migrationQueryKeys: { status: (uid) => ['migration', 'status', uid] },
+}));
+
+// Mock dependencies used by DataManagementDialog via useGdprActions
+vi.mock('../services/gdprDataService', () => ({
+  exportUserData: vi.fn(),
+  deleteAllCloudData: vi.fn(),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: { uid: 'test-uid' } },
+  isAuthenticated: vi.fn(() => true),
+  getCurrentUserId: vi.fn(() => 'test-uid'),
+}));
+
+vi.mock('../hooks/useEntries', () => ({
+  useClearEntriesCache: vi.fn(() => vi.fn()),
 }));
 
 import { signOut, onAuthStateChanged } from '../services/auth';
@@ -394,6 +412,113 @@ describe('UserProfile', () => {
       openMenu();
       expect(screen.getByText('מסונכרן לענן')).toBeInTheDocument();
       expect(screen.queryByText('Local only')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('GDPR data management menu items', () => {
+    const testUser = {
+      uid: 'u1',
+      displayName: 'Test',
+      email: 'test@test.com',
+      photoURL: null,
+    };
+
+    function openMenu() {
+      fireEvent.click(screen.getByRole('button'));
+    }
+
+    it('should show GDPR menu items when migrationStatus is completed', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
+    });
+
+    it('should NOT show GDPR menu items when migrationStatus is idle', () => {
+      useMigration.mockReturnValue({ status: 'idle' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
+      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+    });
+
+    it('should NOT show GDPR menu items when migrationStatus is in-progress', () => {
+      useMigration.mockReturnValue({ status: 'in-progress' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
+      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+    });
+
+    it('should NOT show GDPR menu items when migrationStatus is failed', () => {
+      useMigration.mockReturnValue({ status: 'failed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
+      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+    });
+
+    it('should have FileDownloadIcon SVG on export menu item', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      const exportMenuItem = screen.getByText('ייצוא הנתונים שלי').closest('li');
+      expect(exportMenuItem.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('should have DeleteForeverIcon SVG on delete menu item', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      const deleteMenuItem = screen.getByText('מחיקת נתוני הענן').closest('li');
+      expect(deleteMenuItem.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('should open DataManagementDialog when export is clicked', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      fireEvent.click(screen.getByText('ייצוא הנתונים שלי'));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('should open DataManagementDialog when delete is clicked', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      fireEvent.click(screen.getByText('מחיקת נתוני הענן'));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('should close menu when export item is clicked', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      fireEvent.click(screen.getByText('ייצוא הנתונים שלי'));
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('should close menu when delete item is clicked', () => {
+      useMigration.mockReturnValue({ status: 'completed' });
+      renderWithAuth(<UserProfile />, testUser);
+      openMenu();
+
+      fireEvent.click(screen.getByText('מחיקת נתוני הענן'));
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/hooks/useGdprActions.test.jsx
+++ b/src/hooks/useGdprActions.test.jsx
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../services/gdprDataService', () => ({
+  exportUserData: vi.fn(),
+  deleteAllCloudData: vi.fn(),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: { uid: 'test-user-123' } },
+  isAuthenticated: vi.fn(() => true),
+  getCurrentUserId: vi.fn(() => 'test-user-123'),
+}));
+
+vi.mock('./useEntries', () => ({
+  useClearEntriesCache: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('./useMigration', () => ({
+  migrationQueryKeys: {
+    status: (userId) => ['migration', 'status', userId],
+  },
+}));
+
+import { useGdprActions } from './useGdprActions';
+import { exportUserData, deleteAllCloudData } from '../services/gdprDataService';
+import { getCurrentUserId, isAuthenticated } from '../lib/firebase';
+import { useClearEntriesCache } from './useEntries';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function setupDownloadMocks() {
+  const mockLink = { href: '', download: '', click: vi.fn() };
+  const origCreateElement = document.createElement.bind(document);
+
+  const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+    if (tag === 'a') return mockLink;
+    return origCreateElement(tag);
+  });
+
+  const origAppendChild = document.body.appendChild.bind(document.body);
+  const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+    if (node === mockLink) return node;
+    return origAppendChild(node);
+  });
+
+  const origRemoveChild = document.body.removeChild.bind(document.body);
+  const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => {
+    if (node === mockLink) return node;
+    return origRemoveChild(node);
+  });
+
+  const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+  const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+  return {
+    mockLink,
+    restore() {
+      createElementSpy.mockRestore();
+      appendChildSpy.mockRestore();
+      removeChildSpy.mockRestore();
+      createObjectURLSpy.mockRestore();
+      revokeObjectURLSpy.mockRestore();
+    },
+  };
+}
+
+describe('useGdprActions', () => {
+  let mockClearEntriesCache;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClearEntriesCache = vi.fn();
+    useClearEntriesCache.mockReturnValue(mockClearEntriesCache);
+    isAuthenticated.mockReturnValue(true);
+    getCurrentUserId.mockReturnValue('test-user-123');
+  });
+
+  it('should return all expected properties', () => {
+    const { result } = renderHook(() => useGdprActions(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toHaveProperty('handleExport');
+    expect(result.current).toHaveProperty('isExporting');
+    expect(result.current).toHaveProperty('exportSuccess');
+    expect(result.current).toHaveProperty('exportError');
+    expect(result.current).toHaveProperty('resetExport');
+    expect(result.current).toHaveProperty('handleDelete');
+    expect(result.current).toHaveProperty('isDeleting');
+    expect(result.current).toHaveProperty('deleteSuccess');
+    expect(result.current).toHaveProperty('deleteError');
+    expect(result.current).toHaveProperty('resetDelete');
+  });
+
+  it('should have correct initial state', () => {
+    const { result } = renderHook(() => useGdprActions(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.exportSuccess).toBe(false);
+    expect(result.current.exportError).toBeNull();
+    expect(result.current.isDeleting).toBe(false);
+    expect(result.current.deleteSuccess).toBe(false);
+    expect(result.current.deleteError).toBeNull();
+  });
+
+  describe('handleExport', () => {
+    it('should call exportUserData with the current userId', async () => {
+      const mocks = setupDownloadMocks();
+      const mockData = { exportedAt: '2026-01-01', schemaVersion: 1, entries: [] };
+      exportUserData.mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(exportUserData).toHaveBeenCalledWith('test-user-123');
+      });
+
+      mocks.restore();
+    });
+
+    it('should trigger file download on success', async () => {
+      const mocks = setupDownloadMocks();
+      const mockData = { exportedAt: '2026-01-01', schemaVersion: 1, entries: [{ id: 1 }] };
+      exportUserData.mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportSuccess).toBe(true);
+      });
+
+      expect(mocks.mockLink.click).toHaveBeenCalled();
+      expect(mocks.mockLink.href).toBe('blob:mock-url');
+      expect(mocks.mockLink.download).toMatch(/^maaser-tracker-export-/);
+
+      mocks.restore();
+    });
+
+    it('should set exportSuccess to true on success', async () => {
+      const mocks = setupDownloadMocks();
+      exportUserData.mockResolvedValue({ exportedAt: '2026-01-01', schemaVersion: 1, entries: [] });
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportSuccess).toBe(true);
+      });
+      expect(result.current.isExporting).toBe(false);
+
+      mocks.restore();
+    });
+
+    it('should set exportError on export failure', async () => {
+      const error = new Error('Export failed');
+      exportUserData.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportError).toBeTruthy();
+      });
+      expect(result.current.exportError.message).toBe('Export failed');
+      expect(result.current.isExporting).toBe(false);
+      expect(result.current.exportSuccess).toBe(false);
+    });
+
+    it('should throw when user is not signed in', async () => {
+      isAuthenticated.mockReturnValue(false);
+      getCurrentUserId.mockReturnValue(null);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportError).toBeTruthy();
+      });
+      expect(result.current.exportError.message).toBe('User must be signed in to export data');
+      expect(exportUserData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('should call deleteAllCloudData with the current userId', async () => {
+      deleteAllCloudData.mockResolvedValue({ deletedEntries: 10, migrationReset: true });
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(deleteAllCloudData).toHaveBeenCalledWith('test-user-123');
+      });
+    });
+
+    it('should clear entries cache on success', async () => {
+      deleteAllCloudData.mockResolvedValue({ deletedEntries: 5, migrationReset: true });
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteSuccess).toBe(true);
+      });
+      expect(mockClearEntriesCache).toHaveBeenCalled();
+    });
+
+    it('should set deleteSuccess to true on success', async () => {
+      deleteAllCloudData.mockResolvedValue({ deletedEntries: 0, migrationReset: true });
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteSuccess).toBe(true);
+      });
+      expect(result.current.isDeleting).toBe(false);
+    });
+
+    it('should set deleteError on delete failure', async () => {
+      const error = new Error('Delete failed');
+      deleteAllCloudData.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteError).toBeTruthy();
+      });
+      expect(result.current.deleteError.message).toBe('Delete failed');
+      expect(result.current.isDeleting).toBe(false);
+      expect(result.current.deleteSuccess).toBe(false);
+    });
+
+    it('should throw when user is not signed in', async () => {
+      isAuthenticated.mockReturnValue(false);
+      getCurrentUserId.mockReturnValue(null);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteError).toBeTruthy();
+      });
+      expect(result.current.deleteError.message).toBe('User must be signed in to delete data');
+      expect(deleteAllCloudData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetExport', () => {
+    it('should clear export state', async () => {
+      const error = new Error('fail');
+      exportUserData.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportError).toBeTruthy();
+      });
+
+      act(() => {
+        result.current.resetExport();
+      });
+
+      await waitFor(() => {
+        expect(result.current.exportError).toBeNull();
+      });
+      expect(result.current.exportSuccess).toBe(false);
+      expect(result.current.isExporting).toBe(false);
+    });
+  });
+
+  describe('resetDelete', () => {
+    it('should clear delete state', async () => {
+      const error = new Error('fail');
+      deleteAllCloudData.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useGdprActions(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteError).toBeTruthy();
+      });
+
+      act(() => {
+        result.current.resetDelete();
+      });
+
+      await waitFor(() => {
+        expect(result.current.deleteError).toBeNull();
+      });
+      expect(result.current.deleteSuccess).toBe(false);
+      expect(result.current.isDeleting).toBe(false);
+    });
+  });
+});

--- a/src/services/gdprDataService.test.js
+++ b/src/services/gdprDataService.test.js
@@ -1,0 +1,660 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  doc: vi.fn(),
+  getDocs: vi.fn(),
+  deleteDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: { _type: 'mockFirestore' },
+  auth: { currentUser: null },
+  isAuthenticated: vi.fn(),
+  getCurrentUserId: vi.fn(),
+}));
+
+vi.mock('./firestoreMigrationService', () => ({
+  deleteAllUserEntries: vi.fn(),
+}));
+
+import {
+  exportUserData,
+  deleteAllCloudData,
+  resetMigrationStatus,
+  GdprErrorCodes,
+} from './gdprDataService';
+
+import {
+  collection,
+  doc,
+  getDocs,
+  deleteDoc,
+  writeBatch,
+} from 'firebase/firestore';
+
+import { auth, isAuthenticated, getCurrentUserId } from '../lib/firebase';
+import { deleteAllUserEntries } from './firestoreMigrationService';
+
+const TEST_USER_ID = 'test-user-123';
+
+function setAuthenticated(userId = TEST_USER_ID) {
+  auth.currentUser = { uid: userId };
+  isAuthenticated.mockReturnValue(true);
+  getCurrentUserId.mockReturnValue(userId);
+}
+
+function setUnauthenticated() {
+  auth.currentUser = null;
+  isAuthenticated.mockReturnValue(false);
+  getCurrentUserId.mockReturnValue(null);
+}
+
+describe('gdprDataService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUnauthenticated();
+  });
+
+  describe('GdprErrorCodes', () => {
+    it('should export all expected error codes', () => {
+      expect(GdprErrorCodes.NOT_AUTHENTICATED).toBe('gdpr/not-authenticated');
+      expect(GdprErrorCodes.INVALID_USER_ID).toBe('gdpr/invalid-user-id');
+      expect(GdprErrorCodes.USER_MISMATCH).toBe('gdpr/user-mismatch');
+      expect(GdprErrorCodes.EXPORT_FAILED).toBe('gdpr/export-failed');
+      expect(GdprErrorCodes.DELETE_FAILED).toBe('gdpr/delete-failed');
+      expect(GdprErrorCodes.NETWORK_ERROR).toBe('gdpr/network-error');
+    });
+  });
+
+  describe('exportUserData', () => {
+    it('should return correct envelope structure with entries', async () => {
+      setAuthenticated();
+      const mockDocs = [
+        {
+          data: () => ({
+            type: 'income',
+            amount: 5000,
+            date: '2026-01-01',
+            createdAt: { toDate: () => new Date('2026-01-01T10:00:00Z') },
+            updatedAt: { toDate: () => new Date('2026-01-01T10:00:00Z') },
+          }),
+        },
+        {
+          data: () => ({
+            type: 'donation',
+            amount: 500,
+            date: '2026-01-02',
+            createdAt: { toDate: () => new Date('2026-01-02T10:00:00Z') },
+            updatedAt: null,
+          }),
+        },
+      ];
+      getDocs.mockResolvedValue({ docs: mockDocs });
+      collection.mockReturnValue('entries-ref');
+
+      const result = await exportUserData(TEST_USER_ID);
+
+      expect(result).toHaveProperty('exportedAt');
+      expect(result.schemaVersion).toBe(1);
+      expect(result.entries).toHaveLength(2);
+      expect(typeof result.exportedAt).toBe('string');
+      expect(new Date(result.exportedAt).toISOString()).toBe(result.exportedAt);
+    });
+
+    it('should convert Firestore timestamps to ISO strings', async () => {
+      setAuthenticated();
+      const createdDate = new Date('2026-03-01T12:00:00Z');
+      const updatedDate = new Date('2026-03-02T14:00:00Z');
+      getDocs.mockResolvedValue({
+        docs: [
+          {
+            data: () => ({
+              type: 'income',
+              amount: 1000,
+              createdAt: { toDate: () => createdDate },
+              updatedAt: { toDate: () => updatedDate },
+            }),
+          },
+        ],
+      });
+      collection.mockReturnValue('entries-ref');
+
+      const result = await exportUserData(TEST_USER_ID);
+
+      expect(result.entries[0].createdAt).toBe('2026-03-01T12:00:00.000Z');
+      expect(result.entries[0].updatedAt).toBe('2026-03-02T14:00:00.000Z');
+    });
+
+    it('should handle entries with plain string timestamps', async () => {
+      setAuthenticated();
+      getDocs.mockResolvedValue({
+        docs: [
+          {
+            data: () => ({
+              type: 'income',
+              amount: 1000,
+              createdAt: '2026-01-01',
+              updatedAt: '2026-01-02',
+            }),
+          },
+        ],
+      });
+      collection.mockReturnValue('entries-ref');
+
+      const result = await exportUserData(TEST_USER_ID);
+
+      expect(result.entries[0].createdAt).toBe('2026-01-01');
+      expect(result.entries[0].updatedAt).toBe('2026-01-02');
+    });
+
+    it('should return empty entries array when no cloud data exists', async () => {
+      setAuthenticated();
+      getDocs.mockResolvedValue({ docs: [] });
+      collection.mockReturnValue('entries-ref');
+
+      const result = await exportUserData(TEST_USER_ID);
+
+      expect(result.entries).toEqual([]);
+      expect(result.schemaVersion).toBe(1);
+      expect(result).toHaveProperty('exportedAt');
+    });
+
+    it('should include all entry fields in export', async () => {
+      setAuthenticated();
+      const entryData = {
+        type: 'income',
+        amount: 5000,
+        date: '2026-03-01',
+        accountingMonth: '2026-03',
+        note: 'Salary',
+        createdAt: { toDate: () => new Date('2026-03-01T00:00:00Z') },
+        updatedAt: { toDate: () => new Date('2026-03-01T00:00:00Z') },
+      };
+      getDocs.mockResolvedValue({ docs: [{ data: () => entryData }] });
+      collection.mockReturnValue('entries-ref');
+
+      const result = await exportUserData(TEST_USER_ID);
+
+      expect(result.entries[0].type).toBe('income');
+      expect(result.entries[0].amount).toBe(5000);
+      expect(result.entries[0].date).toBe('2026-03-01');
+      expect(result.entries[0].accountingMonth).toBe('2026-03');
+      expect(result.entries[0].note).toBe('Salary');
+    });
+
+    it('should call collection with correct path', async () => {
+      setAuthenticated();
+      getDocs.mockResolvedValue({ docs: [] });
+      collection.mockReturnValue('entries-ref');
+
+      await exportUserData(TEST_USER_ID);
+
+      expect(collection).toHaveBeenCalledWith(
+        { _type: 'mockFirestore' },
+        'users',
+        TEST_USER_ID,
+        'entries'
+      );
+    });
+
+    it('should throw NOT_AUTHENTICATED when user is not authenticated', async () => {
+      setUnauthenticated();
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should throw INVALID_USER_ID when userId is empty', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('');
+
+      await expect(exportUserData('')).rejects.toMatchObject({
+        code: GdprErrorCodes.INVALID_USER_ID,
+      });
+    });
+
+    it('should throw INVALID_USER_ID when userId is null', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue(null);
+
+      await expect(exportUserData(null)).rejects.toMatchObject({
+        code: GdprErrorCodes.INVALID_USER_ID,
+      });
+    });
+
+    it('should throw INVALID_USER_ID when userId is whitespace only', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('  ');
+
+      await expect(exportUserData('  ')).rejects.toMatchObject({
+        code: GdprErrorCodes.INVALID_USER_ID,
+      });
+    });
+
+    it('should throw USER_MISMATCH when userId does not match authenticated user', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('different-user');
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.USER_MISMATCH,
+      });
+    });
+
+    it('should throw EXPORT_FAILED when Firestore query fails', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      getDocs.mockRejectedValue(new Error('Firestore internal error'));
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.EXPORT_FAILED,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when Firestore returns unavailable', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      const networkError = new Error('Service unavailable');
+      networkError.code = 'unavailable';
+      getDocs.mockRejectedValue(networkError);
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when Firestore returns network-request-failed', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      const networkError = new Error('Network request failed');
+      networkError.code = 'network-request-failed';
+      getDocs.mockRejectedValue(networkError);
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when error message contains network', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      getDocs.mockRejectedValue(new Error('network connection lost'));
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when error message contains offline', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      getDocs.mockRejectedValue(new Error('client is offline'));
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw NOT_AUTHENTICATED for unauthenticated Firestore errors', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      const authError = new Error('Unauthenticated');
+      authError.code = 'unauthenticated';
+      getDocs.mockRejectedValue(authError);
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should throw NOT_AUTHENTICATED for permission-denied Firestore errors', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      const permError = new Error('Permission denied');
+      permError.code = 'permission-denied';
+      getDocs.mockRejectedValue(permError);
+
+      await expect(exportUserData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should preserve original error as cause', async () => {
+      setAuthenticated();
+      collection.mockReturnValue('entries-ref');
+      const originalError = new Error('Original Firestore error');
+      getDocs.mockRejectedValue(originalError);
+
+      try {
+        await exportUserData(TEST_USER_ID);
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error.cause).toBe(originalError);
+      }
+    });
+  });
+
+  describe('deleteAllCloudData', () => {
+    it('should delete all entries and migration data and return result', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(42);
+
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      const result = await deleteAllCloudData(TEST_USER_ID);
+
+      expect(result).toEqual({ deletedEntries: 42, migrationReset: true });
+    });
+
+    it('should call deleteAllUserEntries with the userId', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(0);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(deleteAllUserEntries).toHaveBeenCalledWith(TEST_USER_ID);
+    });
+
+    it('should delete migration history docs in batches', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(10);
+
+      const historyDocs = Array.from({ length: 3 }, (_, i) => ({
+        ref: `history-doc-ref-${i}`,
+      }));
+
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: false, docs: historyDocs });
+
+      const mockBatch = {
+        delete: vi.fn(),
+        commit: vi.fn().mockResolvedValue(),
+      };
+      writeBatch.mockReturnValue(mockBatch);
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(mockBatch.delete).toHaveBeenCalledTimes(3);
+      expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should batch delete history docs in groups of 500', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(0);
+
+      const historyDocs = Array.from({ length: 502 }, (_, i) => ({
+        ref: `history-doc-ref-${i}`,
+      }));
+
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: false, docs: historyDocs });
+
+      const mockBatch = {
+        delete: vi.fn(),
+        commit: vi.fn().mockResolvedValue(),
+      };
+      writeBatch.mockReturnValue(mockBatch);
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(mockBatch.commit).toHaveBeenCalledTimes(2);
+      expect(mockBatch.delete).toHaveBeenCalledTimes(502);
+    });
+
+    it('should delete migration metadata document', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(0);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(doc).toHaveBeenCalledWith(
+        { _type: 'mockFirestore' },
+        'users',
+        TEST_USER_ID,
+        'metadata',
+        'migration'
+      );
+      expect(deleteDoc).toHaveBeenCalledWith('migration-doc-ref');
+    });
+
+    it('should skip batch delete when history is empty', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(5);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(writeBatch).not.toHaveBeenCalled();
+    });
+
+    it('should throw NOT_AUTHENTICATED when user is not authenticated', async () => {
+      setUnauthenticated();
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should throw DELETE_FAILED when deleteAllUserEntries fails', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockRejectedValue(new Error('Delete failed'));
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.DELETE_FAILED,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when entry deletion hits network error', async () => {
+      setAuthenticated();
+      const networkError = new Error('unavailable');
+      networkError.code = 'unavailable';
+      deleteAllUserEntries.mockRejectedValue(networkError);
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw DELETE_FAILED when migration history deletion fails', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(5);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockRejectedValue(new Error('History read failed'));
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.DELETE_FAILED,
+      });
+    });
+
+    it('should throw DELETE_FAILED when migration doc deleteDoc fails', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(5);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockRejectedValue(new Error('Delete doc failed'));
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.DELETE_FAILED,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when migration metadata deletion hits network error', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(5);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      const networkError = new Error('Network failure');
+      networkError.code = 'unavailable';
+      deleteDoc.mockRejectedValue(networkError);
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should preserve original error as cause on entry deletion failure', async () => {
+      setAuthenticated();
+      const originalError = new Error('original');
+      deleteAllUserEntries.mockRejectedValue(originalError);
+
+      try {
+        await deleteAllCloudData(TEST_USER_ID);
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error.cause).toBe(originalError);
+      }
+    });
+
+    it('should throw USER_MISMATCH when userId does not match authenticated user', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('different-user');
+
+      await expect(deleteAllCloudData(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.USER_MISMATCH,
+      });
+    });
+
+    it('should call collection with correct history path', async () => {
+      setAuthenticated();
+      deleteAllUserEntries.mockResolvedValue(0);
+      collection.mockReturnValue('history-ref');
+      getDocs.mockResolvedValue({ empty: true, docs: [] });
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await deleteAllCloudData(TEST_USER_ID);
+
+      expect(collection).toHaveBeenCalledWith(
+        { _type: 'mockFirestore' },
+        'users',
+        TEST_USER_ID,
+        'metadata',
+        'migration',
+        'history'
+      );
+    });
+  });
+
+  describe('resetMigrationStatus', () => {
+    it('should delete migration document', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await resetMigrationStatus(TEST_USER_ID);
+
+      expect(doc).toHaveBeenCalledWith(
+        { _type: 'mockFirestore' },
+        'users',
+        TEST_USER_ID,
+        'metadata',
+        'migration'
+      );
+      expect(deleteDoc).toHaveBeenCalledWith('migration-doc-ref');
+    });
+
+    it('should throw NOT_AUTHENTICATED when user is not authenticated', async () => {
+      setUnauthenticated();
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should throw INVALID_USER_ID when userId is empty', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('');
+
+      await expect(resetMigrationStatus('')).rejects.toMatchObject({
+        code: GdprErrorCodes.INVALID_USER_ID,
+      });
+    });
+
+    it('should throw USER_MISMATCH when userId does not match', async () => {
+      isAuthenticated.mockReturnValue(true);
+      getCurrentUserId.mockReturnValue('other-user');
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.USER_MISMATCH,
+      });
+    });
+
+    it('should handle already-deleted document gracefully (no error on missing doc)', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockResolvedValue();
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).resolves.toBeUndefined();
+    });
+
+    it('should throw DELETE_FAILED when deleteDoc fails', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      deleteDoc.mockRejectedValue(new Error('Delete failed'));
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.DELETE_FAILED,
+      });
+    });
+
+    it('should throw NETWORK_ERROR when deleteDoc hits network error', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      const networkError = new Error('offline');
+      networkError.code = 'unavailable';
+      deleteDoc.mockRejectedValue(networkError);
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NETWORK_ERROR,
+      });
+    });
+
+    it('should throw NOT_AUTHENTICATED for permission-denied Firestore error', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      const permError = new Error('Permission denied');
+      permError.code = 'permission-denied';
+      deleteDoc.mockRejectedValue(permError);
+
+      await expect(resetMigrationStatus(TEST_USER_ID)).rejects.toMatchObject({
+        code: GdprErrorCodes.NOT_AUTHENTICATED,
+      });
+    });
+
+    it('should preserve original error as cause', async () => {
+      setAuthenticated();
+      doc.mockReturnValue('migration-doc-ref');
+      const originalError = new Error('original failure');
+      deleteDoc.mockRejectedValue(originalError);
+
+      try {
+        await resetMigrationStatus(TEST_USER_ID);
+        expect.unreachable('Should have thrown');
+      } catch (error) {
+        expect(error.cause).toBe(originalError);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #64

Adds comprehensive GDPR unit test coverage across all layers:
- **gdprDataService.test.js** — 44 tests (export envelope format, delete batching, auth guards, error categorization)
- **useGdprActions.test.jsx** — 14 tests (mutation states, download trigger, cache invalidation)
- **DataManagementDialog.test.jsx** — 36 tests (6 dialog states, delete confirmation flow, RTL, accessibility)
- **UserProfile.test.jsx** — 10 new tests (GDPR menu item visibility gated on migration status)

**Total: 104 new tests, 1107 suite-wide passing**

## Test plan
- [x] All 1107 tests passing (Vitest)
- [x] ESLint clean — zero errors
- [x] Syntax convention review — no critical issues
- [x] Security review — APPROVED (auth guards tested, no PII, Firebase fully mocked)

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated and passing
- [x] Documentation updated (if needed)
- [x] CI passing
- [x] Ready for review