### PR TITLE
feat: add color-coded character counter to note fields

### DIFF
--- a/src/components/AddDonation.jsx
+++ b/src/components/AddDonation.jsx
@@ -131,9 +131,20 @@ export default function AddDonation({ onAdd, editEntry, onCancel }) {
             onChange={handleNoteChange}
             placeholder={t.noteOptional}
             error={!!noteError}
-            helperText={noteError || `${note.length}/${NOTE_MAX_LENGTH}`}
+            helperText={noteError || `${note.length} / ${NOTE_MAX_LENGTH}`}
             sx={{ mb: 3 }}
             inputProps={{ maxLength: NOTE_MAX_LENGTH + 1 }}
+            FormHelperTextProps={{
+              sx: {
+                color: noteError
+                  ? 'error.main'
+                  : note.length >= NOTE_MAX_LENGTH
+                    ? 'error.main'
+                    : note.length >= 450
+                      ? 'warning.main'
+                      : 'text.secondary',
+              },
+            }}
           />
           <Box sx={{ display: 'flex', gap: 2 }}>
             <Button

--- a/src/components/AddIncome.jsx
+++ b/src/components/AddIncome.jsx
@@ -134,9 +134,20 @@ export default function AddIncome({ onAdd, editEntry, onCancel }) {
             onChange={handleNoteChange}
             placeholder={t.noteOptional}
             error={!!noteError}
-            helperText={noteError || `${note.length}/${NOTE_MAX_LENGTH}`}
+            helperText={noteError || `${note.length} / ${NOTE_MAX_LENGTH}`}
             sx={{ mb: 2 }}
             inputProps={{ maxLength: NOTE_MAX_LENGTH + 1 }}
+            FormHelperTextProps={{
+              sx: {
+                color: noteError
+                  ? 'error.main'
+                  : note.length >= NOTE_MAX_LENGTH
+                    ? 'error.main'
+                    : note.length >= 450
+                      ? 'warning.main'
+                      : 'text.secondary',
+              },
+            }}
           />
           <Box
             sx={{


### PR DESCRIPTION
## Summary
Adds color-coded visual feedback to the existing character counter on note fields in both income and donation forms.

Fixes #28

## Changes
- `src/components/AddIncome.jsx`: Added `FormHelperTextProps` with dynamic color based on character count
- `src/components/AddDonation.jsx`: Same change applied for consistency

Color thresholds:
- **Default** (`text.secondary`/gray): 0-449 characters
- **Warning** (`warning.main`/yellow-orange): 450-499 characters
- **Error** (`error.main`/red): 500 characters (at limit) or validation error

The counter text format was also adjusted from `123/500` to `123 / 500` for readability.

## Testing
- Counter shows gray when under 450 characters
- Counter turns yellow/orange at 450+ characters
- Counter turns red at 500 characters
- Validation error messages still display in red correctly
- Works in both Hebrew and English