### PR TITLE
fix: persist language selection to localStorage

### DIFF
--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -464,14 +464,16 @@ export function LanguageProvider({ children }) {
   const [language, setLanguageState] = useState(getInitialLanguage);
 
   const setLanguage = useCallback((lang) => {
-    const newLang = typeof lang === 'function' ? lang(language) : lang;
-    setLanguageState(newLang);
-    try {
-      localStorage.setItem(LANGUAGE_STORAGE_KEY, newLang);
-    } catch {
-      // localStorage unavailable
-    }
-  }, [language]);
+    setLanguageState((prev) => {
+      const newLang = typeof lang === 'function' ? lang(prev) : lang;
+      try {
+        localStorage.setItem(LANGUAGE_STORAGE_KEY, newLang);
+      } catch {
+        // localStorage unavailable
+      }
+      return newLang;
+    });
+  }, []);
 
   const value = useMemo(() => ({
     language,


### PR DESCRIPTION
## Summary
- Saves user's language preference to `localStorage` so it persists across page refreshes
- Reads from `localStorage` on init, falling back to Hebrew
- Handles `localStorage` being unavailable (private browsing) gracefully

Fixes #50

## Changes
- `src/contexts/LanguageProvider.jsx`: Added `getInitialLanguage()` helper, wrapped `setLanguage` in stable `useCallback` with functional updater pattern (no stale closure)

## Review Notes
- Fixed stale closure bug from original fork PR: `setLanguage` now uses `setLanguageState(prev => ...)` pattern, making the callback stable (empty dep array)