### PR TITLE
#74 Static privacy.html + fix dead links

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Privacy Policy for Ma'aser Tracker - a progressive web app for tracking Jewish charitable giving. Learn how we collect, store, and protect your data.">
+  <title>Privacy Policy - Ma'aser Tracker</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+        Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.7;
+      color: #1a1a1a;
+      background-color: #fafafa;
+      padding: 0;
+    }
+    header { background-color: #1976d2; color: #ffffff; padding: 24px 16px; text-align: center; }
+    header h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 4px; }
+    header p { font-size: 0.875rem; opacity: 0.9; }
+    .app-link-banner {
+      background-color: #e3f2fd; border-bottom: 1px solid #bbdefb;
+      padding: 12px 16px; text-align: center; font-size: 0.875rem; color: #1565c0;
+    }
+    .app-link-banner a { color: #1565c0; font-weight: 600; text-decoration: underline; }
+    .app-link-banner a:hover, .app-link-banner a:focus { color: #0d47a1; }
+    main { max-width: 720px; margin: 0 auto; padding: 32px 20px 64px; }
+    .last-updated { font-size: 0.875rem; color: #666; margin-bottom: 32px; }
+    section { margin-bottom: 32px; }
+    h2 {
+      font-size: 1.25rem; font-weight: 600; color: #1a1a1a;
+      margin-bottom: 12px; padding-bottom: 6px; border-bottom: 2px solid #e0e0e0;
+    }
+    p { margin-bottom: 12px; color: #333; }
+    ul { margin: 12px 0; padding-left: 24px; }
+    li { margin-bottom: 8px; color: #333; }
+    a { color: #1976d2; text-decoration: none; }
+    a:hover, a:focus { text-decoration: underline; color: #1565c0; }
+    footer {
+      max-width: 720px; margin: 0 auto; padding: 24px 20px;
+      border-top: 1px solid #e0e0e0; text-align: center; font-size: 0.8rem; color: #999;
+    }
+    footer a { color: #999; }
+    footer a:hover, footer a:focus { color: #666; }
+    @media (max-width: 480px) {
+      header h1 { font-size: 1.4rem; }
+      main { padding: 24px 16px 48px; }
+      h2 { font-size: 1.125rem; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Privacy Policy</h1>
+    <p>Ma'aser Tracker</p>
+  </header>
+
+  <div class="app-link-banner">
+    <a href="/maaser-tracker/#/privacy">View this page in the app for Hebrew version</a>
+  </div>
+
+  <main>
+    <p class="last-updated">Last updated: March 2026</p>
+
+    <section>
+      <h2>Introduction</h2>
+      <p>Ma'aser Tracker ("the App") is a progressive web application (PWA) for tracking Jewish charitable giving — ma'aser, the practice of donating 10% of one's income to charity. The App is operated as an open-source project and is available at https://dubiwork.github.io/maaser-tracker/. This Privacy Policy explains what data we collect, how we store and use it, and what rights you have regarding your information.</p>
+    </section>
+
+    <section>
+      <h2>Data We Collect</h2>
+      <p>The App collects only the data necessary for its functionality:</p>
+      <ul>
+        <li>Income and donation entries — amounts, dates, and notes that you enter</li>
+        <li>Google account information — email address, display name, and profile photo (only if you choose to sign in with Google Sign-In)</li>
+        <li>Language preference — Hebrew or English</li>
+      </ul>
+      <p>The App does not use cookies, analytics, third-party tracking, or advertising of any kind.</p>
+    </section>
+
+    <section>
+      <h2>How We Store Your Data</h2>
+      <p>Your data is stored in two ways, depending on your choice:</p>
+      <ul>
+        <li>Local storage (IndexedDB) — Your data is stored on your device only, by default. No information is sent to any external server unless you explicitly choose to sync to the cloud.</li>
+        <li>Cloud storage (Firebase Firestore) — If you choose to sync your data, it is stored on Google Cloud (Firebase) servers in the United States. Syncing occurs only after your explicit consent.</li>
+        <li>Authentication (Firebase Authentication) — If you sign in with Google, your authentication details are managed by Google's Firebase Authentication service.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>How We Use Your Data</h2>
+      <p>Your data is used solely for the App's functionality — calculating your ma'aser balance, displaying history, and syncing across devices. We do not sell, share, or transfer your data to any third party, ever. We do not access user data, and we do not analyze it for marketing or commercial purposes.</p>
+    </section>
+
+    <section>
+      <h2>Your Rights (GDPR)</h2>
+      <p>Under the General Data Protection Regulation (GDPR) and other applicable privacy laws, you have the following rights:</p>
+      <ul>
+        <li>Right of access — You can view all your data at any time within the App.</li>
+        <li>Right to data portability (Article 20) — You can export all your data as a JSON file via the "Export my data" option in your User Profile.</li>
+        <li>Right to erasure (Article 17) — You can permanently delete all your cloud data via the "Delete cloud data" option in your User Profile.</li>
+        <li>Right to withdraw consent — You can withdraw your consent to cloud sync at any time. Your local data will remain available on your device.</li>
+      </ul>
+      <p>All of these rights are implemented directly within the App and do not require contacting the developer.</p>
+    </section>
+
+    <section>
+      <h2>Data Security</h2>
+      <p>We take the following measures to protect your data:</p>
+      <ul>
+        <li>All communication with the cloud is conducted over encrypted HTTPS.</li>
+        <li>Firestore security rules ensure that each user can only access their own data.</li>
+        <li>Data access is restricted by user identity (user-scoped access) — no other user or administrator can view your data.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Children's Privacy</h2>
+      <p>The App is not directed at children under the age of 13. We do not knowingly collect personal information from children. If you become aware that a child has provided personal information through the App, please contact us and we will delete the information.</p>
+    </section>
+
+    <section>
+      <h2>Changes to This Policy</h2>
+      <p>We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated "Last updated" date. Continued use of the App after changes are published constitutes acceptance of the updated policy.</p>
+    </section>
+
+    <section>
+      <h2>Contact</h2>
+      <p>For questions or requests regarding this Privacy Policy or your data, you can reach us through the project's GitHub page:</p>
+      <p><a href="https://github.com/DubiWork/maaser-tracker/issues">https://github.com/DubiWork/maaser-tracker/issues</a></p>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      <a href="https://dubiwork.github.io/maaser-tracker/">Ma'aser Tracker</a>
+      — Open-source charitable giving tracker
+    </p>
+  </footer>
+</body>
+</html>

--- a/src/components/MigrationPrompt.jsx
+++ b/src/components/MigrationPrompt.jsx
@@ -63,7 +63,7 @@ import { getAllEntries } from '../services/db';
 const CONSENT_DELAY_MS = 3000; // 3 seconds before showing consent
 const LARGE_DATASET_THRESHOLD = 250;
 const VERY_LARGE_DATASET_THRESHOLD = 500;
-const PRIVACY_POLICY_URL = 'https://github.com/DubiWork/maaser-tracker/blob/main/docs/PRIVACY_POLICY.md';
+const PRIVACY_POLICY_URL = '#/privacy';
 const CONSENT_VERSION = '1.0';
 
 /**
@@ -506,8 +506,6 @@ function MigrationPrompt({ autoTrigger = true, onComplete, onCancel }) {
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
             <Link
               href={PRIVACY_POLICY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
               sx={{ textDecoration: 'underline' }}
             >
               {migrationT.consent?.privacyPolicy || 'Privacy Policy'}

--- a/src/components/SignInDialog.jsx
+++ b/src/components/SignInDialog.jsx
@@ -30,6 +30,7 @@ import {
   ListItemIcon,
   ListItemText,
   Divider,
+  Link,
 } from '@mui/material';
 import DevicesIcon from '@mui/icons-material/Devices';
 import CloudDoneIcon from '@mui/icons-material/CloudDone';
@@ -191,6 +192,16 @@ function SignInDialog({ open, onClose }) {
             {t.signInPrivacyNote || 'Your data is private and encrypted'}
           </Typography>
         </Box>
+
+        {/* Privacy policy link */}
+        <Typography variant="caption" sx={{ display: 'block', textAlign: 'center', mt: 1 }}>
+          <Link
+            href="#/privacy"
+            sx={{ color: 'text.secondary', textDecoration: 'underline' }}
+          >
+            {t.privacyPolicy?.title || 'Privacy Policy'}
+          </Link>
+        </Typography>
       </DialogContent>
 
       <DialogActions sx={{ justifyContent: 'center', pb: 2 }}>


### PR DESCRIPTION
## Summary
Create static privacy.html and fix broken privacy policy links.

Closes #74

## Scope
- `public/privacy.html` — standalone HTML page for crawlers/Google OAuth
- Fix broken link in `MigrationPrompt.jsx:66`
- Add privacy policy link in `SignInDialog.jsx`