### PR TITLE
#87 Firestore security rules audit and test suite

### DIFF
--- a/docs/FIRESTORE_RULES_AUDIT.md
+++ b/docs/FIRESTORE_RULES_AUDIT.md
@@ -1,0 +1,218 @@
+# Firestore Security Rules Audit
+
+**Audit Date:** 2026-03-08
+**Auditor:** Security Auditor Agent
+**File:** `firestore.rules`
+**Rules Version:** 2
+
+---
+
+## Executive Summary
+
+The Firestore security rules for Ma'aser Tracker are **well-structured and production-ready**. All collections enforce authentication, user-scoped access, and appropriate write constraints. No critical or high-severity vulnerabilities were found.
+
+**Overall Rating: PASS**
+
+---
+
+## Rule Structure
+
+```
+cloud.firestore
+└── /databases/{database}/documents
+    ├── /{document=**}                                    → Default deny all
+    ├── /users/{userId}/entries/{entryId}                 → User entries (income/donations)
+    ├── /users/{userId}                                   → User profile/settings
+    ├── /users/{userId}/metadata/migration                → Migration status
+    └── /users/{userId}/metadata/migration/history/{id}   → Migration audit trail
+```
+
+### Helper Functions
+
+| Function | Purpose | Assessment |
+|----------|---------|------------|
+| `isAuthenticated()` | Checks `request.auth != null` | PASS - standard auth gate |
+| `isOwner(userId)` | Checks auth + `request.auth.uid == userId` | PASS - combines auth + ownership |
+
+---
+
+## Detailed Assessment
+
+### 1. Default Deny Policy
+
+**Rule (lines 17-19):**
+```
+match /{document=**} {
+  allow read, write: if false;
+}
+```
+
+| Check | Result |
+|-------|--------|
+| All access denied by default | PASS |
+| No open collections | PASS |
+| No anonymous access paths | PASS |
+| No public read access | PASS |
+
+**Assessment:** Correct default-deny posture. Any path not explicitly matched is denied.
+
+---
+
+### 2. User Entries (`/users/{userId}/entries/{entryId}`)
+
+**Rules (lines 23-39):**
+
+| Operation | Condition | Assessment |
+|-----------|-----------|------------|
+| Read | `isOwner(userId)` | PASS - only owner can read |
+| Create | `isOwner(userId)` AND `request.resource.data.userId == request.auth.uid` | PASS - owner + userId match |
+| Update | `isOwner(userId)` AND `request.resource.data.userId == resource.data.userId` | PASS - owner + userId immutable |
+| Delete | `isOwner(userId)` | PASS - only owner can delete |
+
+**Security Properties:**
+- Authentication required for all operations: PASS
+- Cross-user access prevented: PASS
+- userId field enforced on create: PASS
+- userId field immutable on update: PASS
+- GDPR deletion supported: PASS
+
+---
+
+### 3. User Profile (`/users/{userId}`)
+
+**Rules (lines 43-57):**
+
+| Operation | Condition | Assessment |
+|-----------|-----------|------------|
+| Read | `isOwner(userId)` | PASS |
+| Create | `isOwner(userId)` | PASS |
+| Update | `isOwner(userId)` AND `request.resource.data.uid == resource.data.uid` | PASS - uid immutable |
+| Delete | `isOwner(userId)` | PASS - GDPR account deletion |
+
+**Security Properties:**
+- Authentication required: PASS
+- Cross-user access prevented: PASS
+- uid field immutable on update: PASS
+- Account deletion allowed (GDPR Article 17): PASS
+
+---
+
+### 4. Migration Metadata (`/users/{userId}/metadata/migration`)
+
+**Rules (lines 61-81):**
+
+| Operation | Condition | Assessment |
+|-----------|-----------|------------|
+| Read | `isOwner(userId)` | PASS |
+| Create | `isOwner(userId)` AND `userId` match AND `consentGivenAt != null` AND `consentVersion != null` | PASS - GDPR consent enforced |
+| Update | `isOwner(userId)` AND `userId` match AND `!resource.data.completed` | PASS - completed migrations locked |
+| Delete | `isOwner(userId)` | PASS - GDPR erasure |
+
+**Security Properties:**
+- GDPR consent fields required on creation: PASS
+- Completed migrations immutable (prevents tampering): PASS
+- Cancelled override removed (line 74 security fix): PASS
+- GDPR Article 17 erasure allowed: PASS
+
+---
+
+### 5. Migration History (`/users/{userId}/metadata/migration/history/{eventId}`)
+
+**Rules (lines 85-97):**
+
+| Operation | Condition | Assessment |
+|-----------|-----------|------------|
+| Read | `isOwner(userId)` | PASS |
+| Create | `isOwner(userId)` AND `userId` match | PASS |
+| Update | `if false` | PASS - fully immutable audit trail |
+| Delete | `isOwner(userId)` | PASS - GDPR erasure |
+
+**Security Properties:**
+- Audit trail integrity (updates always denied): PASS
+- History entries immutable: PASS
+- GDPR erasure allowed via delete: PASS
+
+---
+
+## OWASP Mapping
+
+| OWASP Category | Status | Notes |
+|----------------|--------|-------|
+| A01: Broken Access Control | PASS | All paths require auth + ownership check |
+| A02: Cryptographic Failures | N/A | Handled by Firebase infrastructure (TLS, encryption at rest) |
+| A03: Injection | PASS | Firestore rules use structured queries, not string interpolation |
+| A04: Insecure Design | PASS | Default-deny, defense-in-depth with helper functions |
+| A05: Security Misconfiguration | PASS | No overly permissive rules, no wildcard allows |
+| A07: Identification & Auth Failures | PASS | `request.auth != null` enforced on every operation |
+
+---
+
+## Recommendations (Defense-in-Depth Enhancements)
+
+These are not vulnerabilities. The current rules are secure. These are optional hardening suggestions:
+
+### R1: Schema Validation on Entry Creation (Low Priority)
+
+Add required field validation at the rules layer for defense-in-depth:
+
+```
+allow create: if isOwner(userId)
+              && request.resource.data.userId == request.auth.uid
+              && request.resource.data.keys().hasAll(['amount', 'type', 'date', 'userId'])
+              && request.resource.data.type in ['income', 'donation'];
+```
+
+**Rationale:** Currently enforced only at the application layer. Adding rules-layer validation prevents malformed data even if the application code has a bug.
+
+### R2: Document Size Limits (Low Priority)
+
+Add maximum field count constraints to prevent oversized documents:
+
+```
+&& request.resource.data.size() <= 10
+```
+
+**Rationale:** Prevents abuse where a compromised client writes excessively large documents.
+
+### R3: Timestamp Validation (Low Priority)
+
+Consider validating that `consentGivenAt` is a valid timestamp and not in the future:
+
+```
+&& request.resource.data.consentGivenAt is timestamp
+&& request.resource.data.consentGivenAt <= request.time
+```
+
+**Rationale:** Ensures consent timestamps are meaningful for GDPR audit trails.
+
+---
+
+## Test Coverage
+
+A companion test suite validates these rules via static analysis of the rules file content:
+
+**Test file:** `src/services/__tests__/firestore-rules.test.js`
+
+The test suite covers 31 security assertions across all rule blocks, verifying:
+- Default deny policy exists
+- Authentication requirements on all paths
+- Ownership checks on all operations
+- Field immutability constraints
+- GDPR compliance (consent fields, erasure support)
+- Audit trail integrity (history immutability)
+
+---
+
+## Conclusion
+
+The Firestore security rules follow best practices:
+
+1. **Default deny** prevents unauthorized access to any undeclared paths
+2. **Authentication required** on every operation via `isAuthenticated()`
+3. **User-scoped access** via `isOwner(userId)` prevents cross-user data access
+4. **Field immutability** protects userId/uid from modification
+5. **GDPR compliance** enforced at the rules layer (consent fields, erasure rights)
+6. **Audit trail integrity** via fully immutable migration history entries
+7. **Completed migration protection** prevents re-migration or tampering
+
+The rules are production-ready for the Ma'aser Tracker application.

--- a/src/services/__tests__/firestore-rules.test.js
+++ b/src/services/__tests__/firestore-rules.test.js
@@ -1,0 +1,290 @@
+/**
+ * Firestore Security Rules - Static Analysis Test Suite
+ *
+ * Since the Firebase emulator cannot run in CI, this test suite validates the
+ * security properties of firestore.rules by parsing the rules file content
+ * and verifying that expected security patterns exist.
+ *
+ * Each test corresponds to a security requirement from the rules audit
+ * documented in docs/FIRESTORE_RULES_AUDIT.md
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// Read the rules file once for all tests
+let rulesContent;
+
+beforeAll(() => {
+  const rulesPath = path.resolve(process.cwd(), 'firestore.rules');
+  rulesContent = fs.readFileSync(rulesPath, 'utf-8');
+});
+
+/**
+ * Helper: extract a specific match block from the rules file.
+ * Accepts a LITERAL Firestore path (e.g. '/{document=**}') and finds the
+ * corresponding 'match <path> {' in the rules text, then extracts everything
+ * from that match keyword through its balanced closing brace.
+ */
+function extractMatchBlock(rules, literalPath) {
+  const searchStr = 'match ' + literalPath + ' {';
+  const idx = rules.indexOf(searchStr);
+  if (idx === -1) return null;
+
+  let depth = 1;
+  let i = idx + searchStr.length;
+  while (i < rules.length && depth > 0) {
+    if (rules[i] === '{') depth++;
+    if (rules[i] === '}') depth--;
+    i++;
+  }
+  return rules.substring(idx, i);
+}
+
+/**
+ * Helper: extract the /users/{userId} profile block specifically.
+ * Uses indexOf to find 'match /users/{userId} {' in the rules text
+ * and then brace-balances to extract only that block.
+ */
+function extractProfileBlock(rules) {
+  const searchStr = 'match /users/{userId} {';
+  const idx = rules.indexOf(searchStr);
+  if (idx === -1) return null;
+
+  let depth = 1;
+  let i = idx + searchStr.length;
+  while (i < rules.length && depth > 0) {
+    if (rules[i] === '{') depth++;
+    if (rules[i] === '}') depth--;
+    i++;
+  }
+  return rules.substring(idx, i);
+}
+
+describe('Firestore Security Rules - Static Analysis', () => {
+  describe('File Structure', () => {
+    it('should use rules_version 2', () => {
+      expect(rulesContent).toMatch(/rules_version\s*=\s*["']2["']/);
+    });
+
+    it('should define the cloud.firestore service', () => {
+      expect(rulesContent).toMatch(/service\s+cloud\.firestore/);
+    });
+
+    it('should define isAuthenticated helper function', () => {
+      expect(rulesContent).toMatch(
+        /function\s+isAuthenticated\(\)\s*\{[^}]*request\.auth\s*!=\s*null/
+      );
+    });
+
+    it('should define isOwner helper that checks both auth and uid match', () => {
+      expect(rulesContent).toMatch(
+        /function\s+isOwner\(userId\)\s*\{[^}]*isAuthenticated\(\)\s*&&\s*request\.auth\.uid\s*==\s*userId/
+      );
+    });
+  });
+
+  describe('SEC-FS-13: Default Deny Policy', () => {
+    it('should have a root wildcard match that denies all access', () => {
+      const defaultDenyBlock = extractMatchBlock(rulesContent, '/{document=**}');
+      expect(defaultDenyBlock).not.toBeNull();
+      expect(defaultDenyBlock).toMatch(/allow\s+read,\s*write:\s*if\s+false/);
+    });
+  });
+
+  describe('Entries Collection (/users/{userId}/entries/{entryId})', () => {
+    let entriesBlock;
+
+    beforeAll(() => {
+      entriesBlock = extractMatchBlock(
+        rulesContent,
+        '/users/{userId}/entries/{entryId}'
+      );
+    });
+
+    it('should define the entries match block', () => {
+      expect(entriesBlock).not.toBeNull();
+    });
+
+    it('SEC-FS-01 & SEC-FS-02: should require authentication for read and write via isOwner', () => {
+      expect(entriesBlock).toMatch(/allow\s+read:\s*if\s+isOwner\(userId\)/);
+      expect(entriesBlock).toMatch(/allow\s+create:\s*if\s+isOwner\(userId\)/);
+      expect(entriesBlock).toMatch(/allow\s+update:\s*if\s+isOwner\(userId\)/);
+      expect(entriesBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+
+    it('SEC-FS-03 & SEC-FS-04: should scope read access to owner via isOwner(userId)', () => {
+      expect(entriesBlock).toMatch(/allow\s+read:\s*if\s+isOwner\(userId\)/);
+    });
+
+    it('SEC-FS-05: should allow create with matching userId field', () => {
+      expect(entriesBlock).toMatch(
+        /allow\s+create:\s*if\s+isOwner\(userId\)\s*\r?\n?\s*&&\s*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+
+    it('SEC-FS-06 & SEC-FS-14: should require userId field on create that matches auth uid', () => {
+      expect(entriesBlock).toMatch(
+        /allow\s+create:[^;]*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+
+    it('SEC-FS-07: should prevent userId change on update', () => {
+      expect(entriesBlock).toMatch(
+        /allow\s+update:[^;]*request\.resource\.data\.userId\s*==\s*resource\.data\.userId/
+      );
+    });
+
+    it('SEC-FS-08: should scope delete to owner only', () => {
+      expect(entriesBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+  });
+
+  describe('User Profile (/users/{userId})', () => {
+    let profileBlock;
+
+    beforeAll(() => {
+      profileBlock = extractProfileBlock(rulesContent);
+    });
+
+    it('should define the user profile match block', () => {
+      expect(profileBlock).not.toBeNull();
+    });
+
+    it('should require authentication for all operations', () => {
+      expect(profileBlock).toMatch(/allow\s+read:\s*if\s+isOwner\(userId\)/);
+      expect(profileBlock).toMatch(/allow\s+create:\s*if\s+isOwner\(userId\)/);
+      expect(profileBlock).toMatch(/allow\s+update:\s*if\s+isOwner\(userId\)/);
+      expect(profileBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+
+    it('SEC-FS-12: should prevent uid field change on profile update', () => {
+      expect(profileBlock).toMatch(
+        /allow\s+update:[^;]*request\.resource\.data\.uid\s*==\s*resource\.data\.uid/
+      );
+    });
+
+    it('should allow profile deletion for GDPR account removal', () => {
+      expect(profileBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+  });
+
+  describe('Migration Metadata (/users/{userId}/metadata/migration)', () => {
+    let migrationBlock;
+
+    beforeAll(() => {
+      migrationBlock = extractMatchBlock(
+        rulesContent,
+        '/users/{userId}/metadata/migration'
+      );
+    });
+
+    it('should define the migration metadata match block', () => {
+      expect(migrationBlock).not.toBeNull();
+    });
+
+    it('should require GDPR consent fields on migration creation', () => {
+      expect(migrationBlock).toMatch(
+        /allow\s+create:[^;]*consentGivenAt\s*!=\s*null/
+      );
+      expect(migrationBlock).toMatch(
+        /allow\s+create:[^;]*consentVersion\s*!=\s*null/
+      );
+    });
+
+    it('should require userId match on migration creation', () => {
+      expect(migrationBlock).toMatch(
+        /allow\s+create:[^;]*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+
+    it('SEC-FS-09: should prevent update of completed migrations', () => {
+      expect(migrationBlock).toMatch(
+        /allow\s+update:[^;]*!resource\.data\.completed/
+      );
+    });
+
+    it('should require userId match on migration update', () => {
+      expect(migrationBlock).toMatch(
+        /allow\s+update:[^;]*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+
+    it('SEC-FS-11: should allow migration deletion for GDPR erasure', () => {
+      expect(migrationBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+  });
+
+  describe('Migration History (/users/{userId}/metadata/migration/history/{eventId})', () => {
+    let historyBlock;
+
+    beforeAll(() => {
+      historyBlock = extractMatchBlock(
+        rulesContent,
+        '/users/{userId}/metadata/migration/history/{eventId}'
+      );
+    });
+
+    it('should define the migration history match block', () => {
+      expect(historyBlock).not.toBeNull();
+    });
+
+    it('SEC-FS-10: should make history entries fully immutable (deny all updates)', () => {
+      expect(historyBlock).toMatch(/allow\s+update:\s*if\s+false/);
+    });
+
+    it('should require userId match on history creation', () => {
+      expect(historyBlock).toMatch(
+        /allow\s+create:[^;]*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+
+    it('should allow history deletion for GDPR erasure', () => {
+      expect(historyBlock).toMatch(/allow\s+delete:\s*if\s+isOwner\(userId\)/);
+    });
+
+    it('should scope read access to owner only', () => {
+      expect(historyBlock).toMatch(/allow\s+read:\s*if\s+isOwner\(userId\)/);
+    });
+  });
+
+  describe('SEC-FS-15: Comprehensive Entry Creation Validation', () => {
+    it('should enforce both ownership and userId field match for valid entry creation', () => {
+      const entriesBlock = extractMatchBlock(
+        rulesContent,
+        '/users/{userId}/entries/{entryId}'
+      );
+      // A valid creation requires:
+      // 1. isOwner(userId) - path-level ownership (auth.uid == path userId)
+      // 2. request.resource.data.userId == request.auth.uid - document-level userId match
+      expect(entriesBlock).toMatch(
+        /allow\s+create:\s*if\s+isOwner\(userId\)\s*\r?\n?\s*&&\s*request\.resource\.data\.userId\s*==\s*request\.auth\.uid/
+      );
+    });
+  });
+
+  describe('No Overly Permissive Rules', () => {
+    it('should not contain any unconditional allow rules', () => {
+      const unconditionalAllow = /allow\s+(?:read|write|create|update|delete):\s*if\s+true/;
+      expect(rulesContent).not.toMatch(unconditionalAllow);
+    });
+
+    it('should not allow write access via a single broad rule on entries', () => {
+      const entriesBlock = extractMatchBlock(
+        rulesContent,
+        '/users/{userId}/entries/{entryId}'
+      );
+      // Should have separate create, update, delete rules - not a single write
+      expect(entriesBlock).toMatch(/allow\s+create:/);
+      expect(entriesBlock).toMatch(/allow\s+update:/);
+      expect(entriesBlock).toMatch(/allow\s+delete:/);
+      expect(entriesBlock).not.toMatch(/allow\s+write:/);
+    });
+
+    it('should not contain any admin or service account bypass rules', () => {
+      expect(rulesContent).not.toMatch(/request\.auth\.token\.admin/);
+      expect(rulesContent).not.toMatch(/allow\s+.*:\s*if\s+true/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Comprehensive audit of `firestore.rules` — PASS, production-ready
- Created `docs/FIRESTORE_RULES_AUDIT.md` with detailed per-block assessment, OWASP mapping
- Created `src/services/__tests__/firestore-rules.test.js` — 31 static analysis tests covering all 15 SEC-FS test cases
- 3 defense-in-depth recommendations (low priority, not vulnerabilities)

Closes #87

## Test plan
- [x] 31/31 firestore rules tests pass
- [x] Lint clean
- [ ] CI passes