### PR TITLE
#115 Import/Export Translations (Bilingual)

### DIFF
--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -373,6 +373,48 @@ const translations = {
       // Confirmation dialogs
       areYouSure: 'האם אתה בטוח?',
       confirm: 'אישור',
+
+      // Import/Export (local data backup & restore)
+      importExport: {
+        sectionTitle: 'ניהול נתונים',
+        sectionDescription: 'גיבוי, שחזור או העברת הנתונים שלך',
+        // Export
+        exportTitle: 'ייצוא נתונים',
+        exportJSON: 'ייצוא JSON',
+        exportCSV: 'ייצוא CSV',
+        exportSuccess: 'הנתונים יוצאו בהצלחה',
+        exportError: 'ייצוא הנתונים נכשל',
+        exportEmpty: 'אין רשומות לייצוא',
+        exportSecurityWarning: 'קובץ זה מכיל את הנתונים הפיננסיים שלך. שמור אותו במקום בטוח.',
+        // Import
+        importTitle: 'ייבוא נתונים',
+        importButton: 'ייבוא מקובץ',
+        importPreviewTitle: 'תצוגה מקדימה של ייבוא',
+        importFileInfo: 'קובץ: {filename} ({size})',
+        importValidEntries: '{count} רשומות תקינות',
+        importInvalidEntries: '{count} רשומות לא תקינות',
+        importShowInvalid: 'הצג רשומות לא תקינות',
+        importHideInvalid: 'הסתר רשומות לא תקינות',
+        // Conflict modes
+        importModeMerge: 'מיזוג (הוסף הכל)',
+        importModeMergeDesc: 'הוסף רשומות מיובאות לצד הנתונים הקיימים',
+        importModeReplace: 'החלף הכל',
+        importModeReplaceDesc: 'מחק את כל הנתונים הקיימים והחלף בנתונים המיובאים',
+        importReplaceWarning: 'פעולה זו תמחק לצמיתות את כל הרשומות הקיימות שלך!',
+        importReplaceConfirm: 'אני מבין/ה, החלף את כל הנתונים שלי',
+        importAutoBackup: 'גיבוי של הנתונים הנוכחיים שלך יורד תחילה',
+        // Progress & results
+        importProgress: 'מייבא... {current}/{total}',
+        importSuccess: '{count} רשומות יובאו בהצלחה',
+        importError: 'ייבוא הנתונים נכשל',
+        importInvalidFile: 'פורמט קובץ לא חוקי. אנא בחר קובץ JSON או CSV.',
+        importFileTooLarge: 'הקובץ גדול מדי (מקסימום 10 MB)',
+        importFileSizeWarning: 'קובץ גדול ({size}). הייבוא עשוי לקחת רגע.',
+        // Common
+        iosSaveHint: 'הקש על סמל השיתוף כדי לשמור את הקובץ',
+        cancel: 'ביטול',
+        import: 'ייבוא',
+      },
     },
   },
   en: {
@@ -734,6 +776,48 @@ const translations = {
       // Confirmation dialogs
       areYouSure: 'Are you sure?',
       confirm: 'Confirm',
+
+      // Import/Export (local data backup & restore)
+      importExport: {
+        sectionTitle: 'Data Management',
+        sectionDescription: 'Backup, restore, or transfer your data',
+        // Export
+        exportTitle: 'Export Data',
+        exportJSON: 'Export JSON',
+        exportCSV: 'Export CSV',
+        exportSuccess: 'Data exported successfully',
+        exportError: 'Failed to export data',
+        exportEmpty: 'No entries to export',
+        exportSecurityWarning: 'This file contains your financial data. Store it securely.',
+        // Import
+        importTitle: 'Import Data',
+        importButton: 'Import from File',
+        importPreviewTitle: 'Import Preview',
+        importFileInfo: 'File: {filename} ({size})',
+        importValidEntries: '{count} valid entries',
+        importInvalidEntries: '{count} invalid entries',
+        importShowInvalid: 'Show invalid entries',
+        importHideInvalid: 'Hide invalid entries',
+        // Conflict modes
+        importModeMerge: 'Merge (Add All)',
+        importModeMergeDesc: 'Add imported entries alongside existing data',
+        importModeReplace: 'Replace All',
+        importModeReplaceDesc: 'Delete all existing data and replace with imported data',
+        importReplaceWarning: 'This will permanently delete all your existing entries!',
+        importReplaceConfirm: 'I understand, replace all my data',
+        importAutoBackup: 'A backup of your current data will be downloaded first',
+        // Progress & results
+        importProgress: 'Importing... {current}/{total}',
+        importSuccess: 'Successfully imported {count} entries',
+        importError: 'Failed to import data',
+        importInvalidFile: 'Invalid file format. Please select a JSON or CSV file.',
+        importFileTooLarge: 'File is too large (max 10 MB)',
+        importFileSizeWarning: 'Large file ({size}). Import may take a moment.',
+        // Common
+        iosSaveHint: 'Tap the share icon to save the file',
+        cancel: 'Cancel',
+        import: 'Import',
+      },
     },
   },
 };

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -70,6 +70,8 @@ const EXPECTED_SETTINGS_KEYS = [
   // Confirmation dialogs
   'areYouSure',
   'confirm',
+  // Import/Export (nested object)
+  'importExport',
 ];
 
 /**
@@ -126,9 +128,10 @@ describe('Settings Translation Keys', () => {
       }
     });
 
-    it('should have non-empty string values for all keys', () => {
+    it('should have non-empty string values for all flat keys', () => {
       for (const key of EXPECTED_SETTINGS_KEYS) {
         const value = heSettings[key];
+        if (typeof value === 'object') continue; // Skip nested objects (e.g., importExport)
         expect(typeof value).toBe('string');
         expect(value.trim().length).toBeGreaterThan(0);
       }
@@ -155,9 +158,10 @@ describe('Settings Translation Keys', () => {
       }
     });
 
-    it('should have non-empty string values for all keys', () => {
+    it('should have non-empty string values for all flat keys', () => {
       for (const key of EXPECTED_SETTINGS_KEYS) {
         const value = enSettings[key];
+        if (typeof value === 'object') continue; // Skip nested objects (e.g., importExport)
         expect(typeof value).toBe('string');
         expect(value.trim().length).toBeGreaterThan(0);
       }
@@ -196,10 +200,11 @@ describe('Settings Translation Keys', () => {
       expect(Object.keys(heSettings).length).toBe(Object.keys(enSettings).length);
     });
 
-    it('should have different values between languages for all keys', () => {
+    it('should have different values between languages for all flat keys', () => {
       // Every key should have a different value in Hebrew vs English
       // (they are different languages, so values should differ)
       for (const key of EXPECTED_SETTINGS_KEYS) {
+        if (typeof heSettings[key] === 'object') continue; // Skip nested objects
         expect(heSettings[key]).not.toBe(enSettings[key]);
       }
     });
@@ -279,6 +284,116 @@ describe('Settings Translation Keys', () => {
     it('should have the expected number of settings keys', () => {
       expect(Object.keys(heSettings).length).toBe(EXPECTED_SETTINGS_KEYS.length);
       expect(Object.keys(enSettings).length).toBe(EXPECTED_SETTINGS_KEYS.length);
+    });
+  });
+
+  describe('Import/Export translations (settings.importExport)', () => {
+    const EXPECTED_IMPORT_EXPORT_KEYS = [
+      'sectionTitle',
+      'sectionDescription',
+      'exportTitle',
+      'exportJSON',
+      'exportCSV',
+      'exportSuccess',
+      'exportError',
+      'exportEmpty',
+      'exportSecurityWarning',
+      'importTitle',
+      'importButton',
+      'importPreviewTitle',
+      'importFileInfo',
+      'importValidEntries',
+      'importInvalidEntries',
+      'importShowInvalid',
+      'importHideInvalid',
+      'importModeMerge',
+      'importModeMergeDesc',
+      'importModeReplace',
+      'importModeReplaceDesc',
+      'importReplaceWarning',
+      'importReplaceConfirm',
+      'importAutoBackup',
+      'importProgress',
+      'importSuccess',
+      'importError',
+      'importInvalidFile',
+      'importFileTooLarge',
+      'importFileSizeWarning',
+      'iosSaveHint',
+      'cancel',
+      'import',
+    ];
+
+    it('should have importExport as a nested object in both languages', () => {
+      expect(typeof heSettings.importExport).toBe('object');
+      expect(typeof enSettings.importExport).toBe('object');
+    });
+
+    it('should contain all expected import/export keys in Hebrew', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(heSettings.importExport).toHaveProperty(key);
+      }
+    });
+
+    it('should contain all expected import/export keys in English', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(enSettings.importExport).toHaveProperty(key);
+      }
+    });
+
+    it('should have identical key sets in both languages', () => {
+      const heKeys = Object.keys(heSettings.importExport).sort();
+      const enKeys = Object.keys(enSettings.importExport).sort();
+      expect(heKeys).toEqual(enKeys);
+    });
+
+    it('should have the expected number of import/export keys', () => {
+      expect(Object.keys(heSettings.importExport).length).toBe(EXPECTED_IMPORT_EXPORT_KEYS.length);
+      expect(Object.keys(enSettings.importExport).length).toBe(EXPECTED_IMPORT_EXPORT_KEYS.length);
+    });
+
+    it('should have non-empty string values for all import/export keys', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(typeof heSettings.importExport[key]).toBe('string');
+        expect(heSettings.importExport[key].trim().length).toBeGreaterThan(0);
+        expect(typeof enSettings.importExport[key]).toBe('string');
+        expect(enSettings.importExport[key].trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have proper Hebrew content for import/export keys', () => {
+      expect(heSettings.importExport.sectionTitle).toBe('ניהול נתונים');
+      expect(heSettings.importExport.exportTitle).toBe('ייצוא נתונים');
+      expect(heSettings.importExport.importTitle).toBe('ייבוא נתונים');
+    });
+
+    it('should have proper English content for import/export keys', () => {
+      expect(enSettings.importExport.sectionTitle).toBe('Data Management');
+      expect(enSettings.importExport.exportTitle).toBe('Export Data');
+      expect(enSettings.importExport.importTitle).toBe('Import Data');
+    });
+
+    it('should have matching template placeholders in both languages', () => {
+      const templateKeys = [
+        'importFileInfo',
+        'importValidEntries',
+        'importInvalidEntries',
+        'importProgress',
+        'importSuccess',
+        'importFileSizeWarning',
+      ];
+
+      for (const key of templateKeys) {
+        const hePlaceholders = (heSettings.importExport[key].match(/\{[^}]+\}/g) || []).sort();
+        const enPlaceholders = (enSettings.importExport[key].match(/\{[^}]+\}/g) || []).sort();
+        expect(hePlaceholders).toEqual(enPlaceholders);
+      }
+    });
+
+    it('should be separate from dataManagement namespace', () => {
+      // Verify importExport keys do not collide with top-level dataManagement keys
+      expect(heSettings.importExport).not.toBe(heSettings.dataManagement);
+      expect(enSettings.importExport).not.toBe(enSettings.dataManagement);
     });
   });
 });


### PR DESCRIPTION
Closes #115

## Summary
Add ~32 bilingual translation keys (Hebrew + English) for the Import/Export feature under the `settings.importExport.*` namespace.

## Changes
- Add `settings.importExport` namespace to Hebrew translations
- Add `settings.importExport` namespace to English translations
- Keys cover: export buttons/labels, import buttons/labels, file picker, preview dialog, conflict mode radio labels, progress messages, success/error messages, confirmation text

## Notes
- Separate from existing `dataManagement.*` namespace (GDPR export)
- Follows existing nested object pattern in `settings.*`
- Hebrew text is proper Hebrew (not transliteration)