### PR TITLE
#112 Export Service (JSON + CSV)

### DIFF
--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -1,0 +1,374 @@
+/**
+ * Export Service Tests
+ *
+ * Unit tests for JSON/CSV export, filename generation, download trigger,
+ * field stripping, and CSV formula injection prevention.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  exportToJSON,
+  exportToCSV,
+  downloadFile,
+  generateFilename,
+} from '../exportService';
+
+// --- Test fixtures ---
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'entry-1',
+    type: 'income',
+    date: '2026-03-01',
+    amount: 5000,
+    note: 'Salary',
+    accountingMonth: '2026-03',
+    ...overrides,
+  };
+}
+
+function makeEntryWithInternalFields(overrides = {}) {
+  return {
+    ...makeEntry(),
+    createdAt: '2026-03-01T10:00:00.000Z',
+    updatedAt: '2026-03-01T11:00:00.000Z',
+    userId: 'user-123',
+    ...overrides,
+  };
+}
+
+// --- generateFilename ---
+
+describe('generateFilename', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should generate JSON filename with current date', () => {
+    vi.setSystemTime(new Date('2026-03-15'));
+    expect(generateFilename('json')).toBe('maaser-tracker-2026-03-15.json');
+  });
+
+  it('should generate CSV filename with current date', () => {
+    vi.setSystemTime(new Date('2026-03-15'));
+    expect(generateFilename('csv')).toBe('maaser-tracker-2026-03-15.csv');
+  });
+
+  it('should pad single-digit month and day', () => {
+    vi.setSystemTime(new Date('2026-01-05'));
+    expect(generateFilename('json')).toBe('maaser-tracker-2026-01-05.json');
+  });
+
+  it('should handle end of year dates', () => {
+    vi.setSystemTime(new Date('2026-12-31'));
+    expect(generateFilename('csv')).toBe('maaser-tracker-2026-12-31.csv');
+  });
+});
+
+// --- exportToJSON ---
+
+describe('exportToJSON', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should produce valid JSON with schema v1 envelope', () => {
+    const entries = [makeEntry()];
+    const result = exportToJSON(entries);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.exportDate).toBe('2026-03-15T12:00:00.000Z');
+    expect(parsed.entryCount).toBe(1);
+    expect(parsed.entries).toHaveLength(1);
+  });
+
+  it('should include all user-facing entry fields', () => {
+    const entries = [makeEntry()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    const entry = parsed.entries[0];
+
+    expect(entry.id).toBe('entry-1');
+    expect(entry.type).toBe('income');
+    expect(entry.date).toBe('2026-03-01');
+    expect(entry.amount).toBe(5000);
+    expect(entry.note).toBe('Salary');
+    expect(entry.accountingMonth).toBe('2026-03');
+  });
+
+  it('should strip createdAt from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('createdAt');
+  });
+
+  it('should strip updatedAt from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('updatedAt');
+  });
+
+  it('should strip userId from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('userId');
+  });
+
+  it('should handle multiple entries', () => {
+    const entries = [
+      makeEntry({ id: 'entry-1', amount: 5000 }),
+      makeEntry({ id: 'entry-2', type: 'donation', amount: 500 }),
+      makeEntry({ id: 'entry-3', amount: 3000 }),
+    ];
+    const parsed = JSON.parse(exportToJSON(entries));
+
+    expect(parsed.entryCount).toBe(3);
+    expect(parsed.entries).toHaveLength(3);
+    expect(parsed.entries[1].type).toBe('donation');
+  });
+
+  it('should produce pretty-printed JSON (2-space indentation)', () => {
+    const entries = [makeEntry()];
+    const result = exportToJSON(entries);
+    // Pretty-printed JSON contains newlines
+    expect(result).toContain('\n');
+    expect(result).toContain('  ');
+  });
+
+  it('should throw if entries is empty array', () => {
+    expect(() => exportToJSON([])).toThrow('No entries to export');
+  });
+
+  it('should throw if entries is not an array', () => {
+    expect(() => exportToJSON(null)).toThrow('No entries to export');
+    expect(() => exportToJSON(undefined)).toThrow('No entries to export');
+    expect(() => exportToJSON('string')).toThrow('No entries to export');
+    expect(() => exportToJSON(42)).toThrow('No entries to export');
+  });
+
+  it('should not mutate original entries', () => {
+    const original = makeEntryWithInternalFields();
+    const entries = [original];
+    exportToJSON(entries);
+
+    expect(original).toHaveProperty('createdAt');
+    expect(original).toHaveProperty('updatedAt');
+    expect(original).toHaveProperty('userId');
+  });
+
+  it('should handle entries without optional fields', () => {
+    const entry = { id: 'e1', type: 'income', date: '2026-01-01', amount: 100 };
+    const parsed = JSON.parse(exportToJSON([entry]));
+
+    expect(parsed.entries[0].id).toBe('e1');
+    expect(parsed.entries[0]).not.toHaveProperty('note');
+  });
+});
+
+// --- exportToCSV ---
+
+describe('exportToCSV', () => {
+  it('should produce CSV with UTF-8 BOM prefix', async () => {
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    expect(result.charCodeAt(0)).toBe(0xFEFF);
+  });
+
+  it('should include English column headers', async () => {
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    const firstLine = result.replace('\uFEFF', '').split('\n')[0];
+    expect(firstLine).toContain('id');
+    expect(firstLine).toContain('type');
+    expect(firstLine).toContain('date');
+    expect(firstLine).toContain('amount');
+    expect(firstLine).toContain('note');
+    expect(firstLine).toContain('accountingMonth');
+  });
+
+  it('should include entry data in CSV output', async () => {
+    const entries = [makeEntry({ id: 'test-id', amount: 1234 })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('test-id');
+    expect(result).toContain('1234');
+  });
+
+  it('should handle multiple entries', async () => {
+    const entries = [
+      makeEntry({ id: 'e1' }),
+      makeEntry({ id: 'e2', type: 'donation' }),
+    ];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('e1');
+    expect(result).toContain('e2');
+  });
+
+  it('should strip internal fields from CSV export', async () => {
+    const entries = [makeEntryWithInternalFields()];
+    const result = await exportToCSV(entries);
+    expect(result).not.toContain('createdAt');
+    expect(result).not.toContain('updatedAt');
+    expect(result).not.toContain('userId');
+  });
+
+  it('should sanitize cells starting with = to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '=SUM(A1:A10)' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'=SUM(A1:A10)");
+  });
+
+  it('should sanitize cells starting with + to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '+cmd|calc' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'+cmd|calc");
+  });
+
+  it('should sanitize cells starting with - to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '-1+1' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'-1+1");
+  });
+
+  it('should sanitize cells starting with @ to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '@SUM(A1)' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'@SUM(A1)");
+  });
+
+  it('should not sanitize normal text values', async () => {
+    const entries = [makeEntry({ note: 'Normal salary payment' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('Normal salary payment');
+    // Should not have a leading quote
+    expect(result).not.toContain("'Normal salary payment");
+  });
+
+  it('should throw if entries is empty array', async () => {
+    await expect(exportToCSV([])).rejects.toThrow('No entries to export');
+  });
+
+  it('should throw if entries is not an array', async () => {
+    await expect(exportToCSV(null)).rejects.toThrow('No entries to export');
+    await expect(exportToCSV(undefined)).rejects.toThrow('No entries to export');
+  });
+
+  it('should load PapaParse via dynamic import', async () => {
+    // PapaParse is loaded dynamically — the test succeeds only if the import works
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('should handle entries with Hebrew text', async () => {
+    const entries = [makeEntry({ note: 'משכורת חודשית' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('משכורת חודשית');
+  });
+});
+
+// --- downloadFile ---
+
+describe('downloadFile', () => {
+  let createObjectURLMock;
+  let revokeObjectURLMock;
+  let appendChildSpy;
+  let removeChildSpy;
+  let clickSpy;
+
+  beforeEach(() => {
+    createObjectURLMock = vi.fn().mockReturnValue('blob:mock-url');
+    revokeObjectURLMock = vi.fn();
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+
+    clickSpy = vi.fn();
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+    removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        return {
+          href: '',
+          download: '',
+          style: {},
+          click: clickSpy,
+        };
+      }
+      return document.createElement(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create a Blob with the correct content and MIME type', () => {
+    downloadFile('test content', 'test.json', 'application/json');
+    expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  it('should set anchor download attribute to filename', () => {
+    let capturedAnchor;
+    document.createElement.mockImplementation((tag) => {
+      if (tag === 'a') {
+        capturedAnchor = { href: '', download: '', style: {}, click: clickSpy };
+        return capturedAnchor;
+      }
+    });
+
+    downloadFile('data', 'myfile.csv', 'text/csv');
+    expect(capturedAnchor.download).toBe('myfile.csv');
+  });
+
+  it('should click the anchor to trigger download', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should revoke the Blob URL after download', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('should append and remove the anchor from the DOM', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+  });
+
+  it('should return downloaded: true and iosSafari: false for normal browsers', () => {
+    const result = downloadFile('data', 'test.json', 'application/json');
+    expect(result).toEqual({ downloaded: true, iosSafari: false });
+  });
+
+  it('should detect iOS Safari and open in new tab instead', () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {});
+
+    // Simulate iOS Safari user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+      configurable: true,
+    });
+
+    const result = downloadFile('data', 'test.json', 'application/json');
+
+    expect(openSpy).toHaveBeenCalledWith('blob:mock-url', '_blank');
+    expect(result).toEqual({ downloaded: true, iosSafari: true });
+    // On iOS Safari, click should NOT be called (opens in new tab instead)
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    openSpy.mockRestore();
+  });
+});

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -1,0 +1,175 @@
+/**
+ * Export Service for Ma'aser Tracker
+ *
+ * Provides JSON and CSV export functionality for entry data.
+ * CSV uses PapaParse (dynamic import) with UTF-8 BOM for Hebrew Excel compatibility.
+ * Includes formula injection prevention for CSV cells.
+ */
+
+/** Current export schema version */
+const EXPORT_SCHEMA_VERSION = 1;
+
+/** Internal fields that should be stripped from exported entries */
+const INTERNAL_FIELDS = ['createdAt', 'updatedAt', 'userId'];
+
+/** Characters that trigger formula execution in spreadsheet applications */
+const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@'];
+
+/** UTF-8 BOM for Excel Hebrew compatibility */
+const UTF8_BOM = '\uFEFF';
+
+/** CSV column headers (English) */
+const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'note', 'accountingMonth'];
+
+/**
+ * Strip internal/server-side fields from an entry for export.
+ * @param {Object} entry - Entry object potentially containing internal fields
+ * @returns {Object} Entry with internal fields removed
+ */
+function stripInternalFields(entry) {
+  const cleaned = { ...entry };
+  for (const field of INTERNAL_FIELDS) {
+    delete cleaned[field];
+  }
+  return cleaned;
+}
+
+/**
+ * Sanitize a cell value to prevent CSV formula injection.
+ * Prefixes cells starting with =, +, -, @ with a single quote.
+ * @param {*} value - Cell value to sanitize
+ * @returns {*} Sanitized value (string if prefixed, original otherwise)
+ */
+function sanitizeCsvCell(value) {
+  if (typeof value !== 'string') return value;
+  if (value.length === 0) return value;
+  if (FORMULA_TRIGGER_CHARS.includes(value[0])) {
+    return "'" + value;
+  }
+  return value;
+}
+
+/**
+ * Sanitize all string fields in an entry for CSV export.
+ * @param {Object} entry - Entry object
+ * @returns {Object} Entry with sanitized string fields
+ */
+function sanitizeEntryForCsv(entry) {
+  const sanitized = {};
+  for (const [key, value] of Object.entries(entry)) {
+    sanitized[key] = sanitizeCsvCell(value);
+  }
+  return sanitized;
+}
+
+/**
+ * Generate a filename for export.
+ * @param {'json' | 'csv'} format - Export format
+ * @returns {string} Filename in format: maaser-tracker-YYYY-MM-DD.{json|csv}
+ */
+export function generateFilename(format) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `maaser-tracker-${year}-${month}-${day}.${format}`;
+}
+
+/**
+ * Export entries to JSON format with a schema v1 envelope.
+ * Strips internal fields (createdAt, updatedAt, userId) from entries.
+ *
+ * @param {Array<Object>} entries - Array of entry objects to export
+ * @returns {string} JSON string with schema envelope
+ * @throws {Error} If entries is empty or not an array
+ */
+export function exportToJSON(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('No entries to export');
+  }
+
+  const cleanedEntries = entries.map(stripInternalFields);
+
+  const envelope = {
+    version: EXPORT_SCHEMA_VERSION,
+    exportDate: new Date().toISOString(),
+    entryCount: cleanedEntries.length,
+    entries: cleanedEntries,
+  };
+
+  return JSON.stringify(envelope, null, 2);
+}
+
+/**
+ * Export entries to CSV format using PapaParse.
+ * Includes UTF-8 BOM prefix for Hebrew Excel compatibility.
+ * Prevents formula injection by prefixing dangerous cell values.
+ * PapaParse is loaded via dynamic import to enable code splitting.
+ *
+ * @param {Array<Object>} entries - Array of entry objects to export
+ * @returns {Promise<string>} CSV string with UTF-8 BOM prefix
+ * @throws {Error} If entries is empty or not an array
+ */
+export async function exportToCSV(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('No entries to export');
+  }
+
+  const Papa = await import('papaparse');
+
+  const cleanedEntries = entries.map(stripInternalFields);
+  const sanitizedEntries = cleanedEntries.map(sanitizeEntryForCsv);
+
+  const csv = Papa.default.unparse(sanitizedEntries, {
+    columns: CSV_HEADERS,
+    header: true,
+  });
+
+  return UTF8_BOM + csv;
+}
+
+/**
+ * Detect if the current browser is iOS Safari.
+ * On iOS Safari, programmatic download is unreliable.
+ * @returns {boolean} True if running on iOS Safari
+ */
+function isIOSSafari() {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
+  const isSafari = /^((?!chrome|android).)*safari/i.test(ua);
+  return isIOS && isSafari;
+}
+
+/**
+ * Trigger a file download in the browser.
+ * Creates a temporary Blob URL, clicks an anchor element, then revokes the URL.
+ * On iOS Safari, opens the content in a new tab with a save instruction.
+ *
+ * @param {string} content - File content to download
+ * @param {string} filename - Name for the downloaded file
+ * @param {string} mimeType - MIME type of the content (e.g., 'application/json', 'text/csv')
+ * @returns {{ downloaded: boolean, iosSafari: boolean }} Result indicating download method used
+ */
+export function downloadFile(content, filename, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  if (isIOSSafari()) {
+    window.open(url, '_blank');
+    // Revoke after a delay to allow the new tab to load
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+    return { downloaded: true, iosSafari: true };
+  }
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+
+  return { downloaded: true, iosSafari: false };
+}


### PR DESCRIPTION
## Summary

Closes #112

Implements the export service layer (`src/services/exportService.js`) with:
- `exportToJSON()` - JSON export with schema v1 envelope
- `exportToCSV()` - CSV export via PapaParse with UTF-8 BOM for Hebrew Excel
- `downloadFile()` - Blob URL download with iOS Safari detection
- `generateFilename()` - Date-based filename generation

## Checklist
- [ ] Tests passing
- [ ] Lint clean
- [ ] Coverage >= 80% statements, >= 75% branches
- [ ] No test regressions