### PR TITLE
#41 Import/Export JSON & CSV — Promote to production

### DIFF
--- a/.github/REGRESSION_TEST_PLAN.md
+++ b/.github/REGRESSION_TEST_PLAN.md
@@ -112,7 +112,19 @@ For each test case below:
 
 ---
 
-## Total Test Cases: 33
+## Import/Export Flows (Added: Issue #117)
+
+| ID | Preconditions | Steps | Expected Result |
+|----|--------------|-------|----------------|
+| RT-IE-01 | User signed in. At least 5 entries exist (mix of income and donation). | 1. Navigate to Settings or Import/Export page. 2. Click "Export JSON". 3. Verify JSON file downloads. 4. Clear all entries (or use Replace mode). 5. Click "Import". 6. Select the exported JSON file. 7. Choose "Replace All" mode. 8. Confirm import. 9. Return to Dashboard. | JSON file downloads with correct filename (maaser-tracker-YYYY-MM-DD.json). Import succeeds with all entries restored. Dashboard totals match pre-export values. No console errors. |
+| RT-IE-02 | User signed in. At least 3 entries with Hebrew notes exist. | 1. Click "Export CSV". 2. Open exported CSV file in Excel or Google Sheets. 3. Verify column headers are present (id, type, date, amount, note, accountingMonth). 4. Verify Hebrew text displays correctly. 5. Verify amounts are numeric (not text). | CSV file opens correctly in spreadsheet application. Hebrew text renders properly (not garbled). Amounts are recognized as numbers. BOM prefix ensures correct encoding. No formula injection (cells starting with =, +, -, @ are prefixed with '). |
+| RT-IE-03 | User signed in. Excel or text editor available. | 1. Create a CSV file with Hebrew headers: סוג,סכום,תאריך,הערה. 2. Add rows: הכנסה,5000,15/03/2026,משכורת and תרומה,500,16/03/2026,צדקה. 3. Save as UTF-8 CSV. 4. Import the file in the app. 5. Check History page. | Both entries imported correctly. Hebrew type values mapped (הכנסה→income, תרומה→donation). Dates parsed correctly (DD/MM/YYYY format). Hebrew notes preserved. No console errors. |
+| RT-IE-04 | User signed in. | 1. Attempt to import a malformed JSON file (e.g., `{ broken }}`). 2. Attempt to import a JSON with wrong schema version. 3. Attempt to import a CSV missing required columns. | Each attempt shows a clear, user-friendly error message. No data is modified in the database. App remains functional after each failed import. No console errors or crashes. |
+| RT-IE-05 | User signed in. At least 100 entries exist (or import a large file). | 1. Export all entries as JSON. 2. Import the file using "Replace All" mode. 3. Observe progress indicator during import. 4. Verify completion. | Progress bar/indicator is visible during import. Import completes successfully within 30 seconds. All entries present after import. Dashboard recalculates correctly. No console errors. |
+
+---
+
+## Total Test Cases: 38
 
 | Category | Count |
 |----------|-------|
@@ -125,9 +137,10 @@ For each test case below:
 | Accounting Month | 2 |
 | GDPR Data Management (Issue #53) | 3 |
 | Privacy Policy (Issue #56) | 3 |
-| **Total** | **33** |
+| Import/Export (Issue #117) | 5 |
+| **Total** | **38** |
 
 ---
 
-**Last Updated:** 2026-03-08
-**Updated By:** Quality validation -- Issue #89
+**Last Updated:** 2026-03-09
+**Updated By:** Integration testing -- Issue #117

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^12.10.0",
         "gapi-script": "^1.2.0",
         "idb": "^8.0.3",
+        "papaparse": "^5.5.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "stylis-plugin-rtl": "^2.1.1",
@@ -8108,6 +8109,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "firebase": "^12.10.0",
     "gapi-script": "^1.2.0",
     "idb": "^8.0.3",
+    "papaparse": "^5.5.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "stylis-plugin-rtl": "^2.1.1",

--- a/src/components/ImportExportSection.jsx
+++ b/src/components/ImportExportSection.jsx
@@ -1,0 +1,189 @@
+/**
+ * ImportExportSection Component
+ *
+ * Section 5 in SettingsPage — "Data Management" for local data backup/restore.
+ * Provides export buttons (JSON/CSV) and import button with hidden file input.
+ * Launches ImportPreviewDialog on file selection.
+ */
+
+import { useState, useRef, useCallback, memo } from 'react';
+import {
+  Paper,
+  Typography,
+  Box,
+  Button,
+  Divider,
+  Snackbar,
+  Alert,
+  Tooltip,
+} from '@mui/material';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import TableChartIcon from '@mui/icons-material/TableChart';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import { useLanguage } from '../contexts/useLanguage';
+import { useEntries } from '../hooks/useEntries';
+import { useExportJSON, useExportCSV, useImport } from '../hooks/useImportExport';
+import ImportPreviewDialog from './ImportPreviewDialog';
+
+function ImportExportSection() {
+  const { t } = useLanguage();
+  const { data: entries } = useEntries();
+  const exportJSON = useExportJSON();
+  const exportCSV = useExportCSV();
+  const importHook = useImport();
+  const fileInputRef = useRef(null);
+
+  const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'info' });
+
+  const st = t.settings?.importExport || {};
+  const hasEntries = entries && entries.length > 0;
+  const isOperationActive = exportJSON.isExporting || exportCSV.isExporting;
+
+  const handleExportJSON = useCallback(async () => {
+    await exportJSON.exportJSON();
+    if (exportJSON.error) {
+      setSnackbar({ open: true, message: st.exportError || 'Failed to export data', severity: 'error' });
+    } else if (exportJSON.isIOS) {
+      setSnackbar({ open: true, message: st.iosSaveHint || 'Tap the share icon to save the file', severity: 'info' });
+    } else {
+      setSnackbar({ open: true, message: st.exportSecurityWarning || 'This file contains your financial data. Store it securely.', severity: 'warning' });
+    }
+  }, [exportJSON, st.exportError, st.iosSaveHint, st.exportSecurityWarning]);
+
+  const handleExportCSV = useCallback(async () => {
+    await exportCSV.exportCSV();
+    if (exportCSV.error) {
+      setSnackbar({ open: true, message: st.exportError || 'Failed to export data', severity: 'error' });
+    } else if (exportCSV.isIOS) {
+      setSnackbar({ open: true, message: st.iosSaveHint || 'Tap the share icon to save the file', severity: 'info' });
+    } else {
+      setSnackbar({ open: true, message: st.exportSecurityWarning || 'This file contains your financial data. Store it securely.', severity: 'warning' });
+    }
+  }, [exportCSV, st.exportError, st.iosSaveHint, st.exportSecurityWarning]);
+
+  const handleImportClick = useCallback(() => {
+    if (fileInputRef.current) {
+      // Reset the value so re-selecting the same file fires onChange
+      fileInputRef.current.value = '';
+      fileInputRef.current.click();
+    }
+  }, []);
+
+  const handleFileChange = useCallback((event) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      importHook.parseFile(file);
+    }
+  }, [importHook]);
+
+  const handleCloseSnackbar = useCallback(() => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handleDialogClose = useCallback(() => {
+    importHook.reset();
+  }, [importHook]);
+
+  const noEntriesTooltip = st.exportEmpty || 'No entries to export';
+
+  return (
+    <>
+      <Paper sx={{ p: 2, mb: 2 }} data-testid="import-export-section">
+        <Typography variant="h6" component="h2" sx={{ fontWeight: 500, mb: 0.5 }}>
+          {st.sectionTitle || 'Data Management'}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {st.sectionDescription || 'Backup, restore, or transfer your data'}
+        </Typography>
+
+        {/* Export area */}
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          {st.exportTitle || 'Export Data'}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+          <Tooltip title={hasEntries ? '' : noEntriesTooltip} arrow>
+            <span>
+              <Button
+                variant="outlined"
+                startIcon={<FileDownloadIcon />}
+                onClick={handleExportJSON}
+                disabled={!hasEntries || isOperationActive}
+                sx={{ textTransform: 'none' }}
+                aria-label={st.exportJSON || 'Export JSON'}
+              >
+                {st.exportJSON || 'Export JSON'}
+              </Button>
+            </span>
+          </Tooltip>
+          <Tooltip title={hasEntries ? '' : noEntriesTooltip} arrow>
+            <span>
+              <Button
+                variant="outlined"
+                startIcon={<TableChartIcon />}
+                onClick={handleExportCSV}
+                disabled={!hasEntries || isOperationActive}
+                sx={{ textTransform: 'none' }}
+                aria-label={st.exportCSV || 'Export CSV'}
+              >
+                {st.exportCSV || 'Export CSV'}
+              </Button>
+            </span>
+          </Tooltip>
+        </Box>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Import area */}
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          {st.importTitle || 'Import Data'}
+        </Typography>
+        <Button
+          variant="outlined"
+          fullWidth
+          startIcon={<FileUploadIcon />}
+          onClick={handleImportClick}
+          disabled={isOperationActive}
+          sx={{ textTransform: 'none' }}
+          aria-label={st.importButton || 'Import from File'}
+        >
+          {st.importButton || 'Import from File'}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,.csv"
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+          aria-hidden="true"
+          data-testid="import-file-input"
+        />
+      </Paper>
+
+      {/* Import Preview Dialog */}
+      <ImportPreviewDialog
+        open={importHook.state !== 'idle'}
+        importHook={importHook}
+        onClose={handleDialogClose}
+      />
+
+      {/* Snackbar for export feedback */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
+export default memo(ImportExportSection);

--- a/src/components/ImportExportSection.test.jsx
+++ b/src/components/ImportExportSection.test.jsx
@@ -1,0 +1,289 @@
+/**
+ * ImportExportSection Component Tests
+ *
+ * Tests for export/import buttons, disabled states, and file picker behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../contexts/useLanguage', () => ({
+  useLanguage: vi.fn(),
+}));
+
+vi.mock('../hooks/useEntries', () => ({
+  useEntries: vi.fn(),
+  queryKeys: {
+    all: ['entries'],
+    lists: () => ['entries', 'list'],
+    list: (f) => ['entries', 'list', f],
+    details: () => ['entries', 'detail'],
+    detail: (id) => ['entries', 'detail', id],
+    migrationStatus: (uid) => ['migration', 'status', uid],
+  },
+  useMigrationStatus: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock('../hooks/useImportExport', () => ({
+  useExportJSON: vi.fn(),
+  useExportCSV: vi.fn(),
+  useImport: vi.fn(),
+  ImportState: {
+    IDLE: 'idle',
+    PARSING: 'parsing',
+    PREVIEW: 'preview',
+    IMPORTING: 'importing',
+    SUCCESS: 'success',
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('./ImportPreviewDialog', () => ({
+  default: vi.fn(({ open }) => open ? <div data-testid="import-preview-dialog">Import Preview Dialog</div> : null),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: null },
+  isAuthenticated: vi.fn(() => false),
+  getCurrentUserId: vi.fn(() => null),
+}));
+
+import { useLanguage } from '../contexts/useLanguage';
+import { useEntries } from '../hooks/useEntries';
+import { useExportJSON, useExportCSV, useImport } from '../hooks/useImportExport';
+import ImportExportSection from './ImportExportSection';
+
+const defaultTranslations = {
+  settings: {
+    importExport: {
+      sectionTitle: 'Data Management',
+      sectionDescription: 'Backup, restore, or transfer your data',
+      exportTitle: 'Export Data',
+      exportJSON: 'Export JSON',
+      exportCSV: 'Export CSV',
+      exportSuccess: 'Data exported successfully',
+      exportError: 'Failed to export data',
+      exportEmpty: 'No entries to export',
+      exportSecurityWarning: 'Store it securely.',
+      importTitle: 'Import Data',
+      importButton: 'Import from File',
+      iosSaveHint: 'Tap the share icon to save',
+    },
+  },
+  cancel: 'Cancel',
+  tryAgain: 'Try Again',
+};
+
+function setupMocks(overrides = {}) {
+  useLanguage.mockReturnValue({
+    t: overrides.t || defaultTranslations,
+    direction: overrides.direction || 'ltr',
+  });
+
+  useEntries.mockReturnValue({
+    data: 'entries' in overrides ? overrides.entries : [{ id: '1', type: 'income', amount: 5000 }],
+  });
+
+  useExportJSON.mockReturnValue({
+    exportJSON: overrides.exportJSON || vi.fn(),
+    isExporting: overrides.isExportingJSON || false,
+    error: overrides.exportJSONError || null,
+    isIOS: overrides.isIOS || false,
+    reset: vi.fn(),
+  });
+
+  useExportCSV.mockReturnValue({
+    exportCSV: overrides.exportCSV || vi.fn(),
+    isExporting: overrides.isExportingCSV || false,
+    error: overrides.exportCSVError || null,
+    isIOS: overrides.isIOS || false,
+    reset: vi.fn(),
+  });
+
+  useImport.mockReturnValue({
+    state: overrides.importState || 'idle',
+    parseResult: overrides.parseResult || null,
+    importResult: overrides.importResult || null,
+    error: overrides.importError || null,
+    progress: overrides.progress || { current: 0, total: 0, phase: '' },
+    parseFile: overrides.parseFile || vi.fn(),
+    executeImport: overrides.executeImport || vi.fn(),
+    reset: overrides.importReset || vi.fn(),
+    retry: overrides.importRetry || vi.fn(),
+  });
+}
+
+function renderSection(props = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ImportExportSection {...props} />
+    </QueryClientProvider>
+  );
+}
+
+describe('ImportExportSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render section title and description', () => {
+      renderSection();
+
+      expect(screen.getByText('Data Management')).toBeInTheDocument();
+      expect(screen.getByText('Backup, restore, or transfer your data')).toBeInTheDocument();
+    });
+
+    it('should render Export JSON button', () => {
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeInTheDocument();
+    });
+
+    it('should render Export CSV button', () => {
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
+    });
+
+    it('should render Import from File button', () => {
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Import from File' })).toBeInTheDocument();
+    });
+
+    it('should render hidden file input with correct accept attribute', () => {
+      renderSection();
+
+      const fileInput = screen.getByTestId('import-file-input');
+      expect(fileInput).toHaveAttribute('accept', '.json,.csv');
+      expect(fileInput).toHaveAttribute('type', 'file');
+    });
+
+    it('should have data-testid on section container', () => {
+      renderSection();
+
+      expect(screen.getByTestId('import-export-section')).toBeInTheDocument();
+    });
+  });
+
+  describe('disabled states', () => {
+    it('should disable export buttons when no entries exist', () => {
+      setupMocks({ entries: [] });
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled();
+    });
+
+    it('should disable export buttons when entries are null', () => {
+      setupMocks({ entries: null });
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled();
+    });
+
+    it('should enable export buttons when entries exist', () => {
+      setupMocks({ entries: [{ id: '1' }] });
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).not.toBeDisabled();
+    });
+
+    it('should disable buttons during JSON export operation', () => {
+      setupMocks({ isExportingJSON: true });
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Import from File' })).toBeDisabled();
+    });
+
+    it('should disable buttons during CSV export operation', () => {
+      setupMocks({ isExportingCSV: true });
+      renderSection();
+
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeDisabled();
+    });
+  });
+
+  describe('export actions', () => {
+    it('should call exportJSON when Export JSON button is clicked', () => {
+      const mockExport = vi.fn();
+      setupMocks({ exportJSON: mockExport });
+      renderSection();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Export JSON' }));
+
+      expect(mockExport).toHaveBeenCalled();
+    });
+
+    it('should call exportCSV when Export CSV button is clicked', () => {
+      const mockExport = vi.fn();
+      setupMocks({ exportCSV: mockExport });
+      renderSection();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
+
+      expect(mockExport).toHaveBeenCalled();
+    });
+  });
+
+  describe('import actions', () => {
+    it('should call parseFile when a file is selected', () => {
+      const mockParseFile = vi.fn();
+      setupMocks({ parseFile: mockParseFile });
+      renderSection();
+
+      const fileInput = screen.getByTestId('import-file-input');
+      const mockFile = new File(['{}'], 'test.json', { type: 'application/json' });
+
+      fireEvent.change(fileInput, { target: { files: [mockFile] } });
+
+      expect(mockParseFile).toHaveBeenCalledWith(mockFile);
+    });
+
+    it('should open ImportPreviewDialog when import state is not idle', () => {
+      setupMocks({ importState: 'preview' });
+      renderSection();
+
+      expect(screen.getByTestId('import-preview-dialog')).toBeInTheDocument();
+    });
+
+    it('should not open ImportPreviewDialog when import state is idle', () => {
+      setupMocks({ importState: 'idle' });
+      renderSection();
+
+      expect(screen.queryByTestId('import-preview-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('RTL support', () => {
+    it('should render correctly in RTL mode', () => {
+      setupMocks({ direction: 'rtl' });
+      renderSection();
+
+      expect(screen.getByText('Data Management')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeInTheDocument();
+    });
+  });
+
+  describe('section headings', () => {
+    it('should render export and import subsection headings', () => {
+      renderSection();
+
+      expect(screen.getByText('Export Data')).toBeInTheDocument();
+      expect(screen.getByText('Import Data')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ImportPreviewDialog.jsx
+++ b/src/components/ImportPreviewDialog.jsx
@@ -1,0 +1,447 @@
+/**
+ * ImportPreviewDialog Component
+ *
+ * State-machine dialog for previewing and executing data imports.
+ * States: IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ *
+ * Features:
+ * - File info display
+ * - Valid/invalid entry counts
+ * - Sample entries table (first 5)
+ * - Merge/Replace radio group
+ * - Replace mode: warning alert + confirmation checkbox
+ * - LinearProgress during import
+ * - RTL support
+ * - Accessible: aria-live, focus management, keyboard navigation
+ * - Full-screen on mobile (<600px)
+ */
+
+import { useState, useCallback, useRef, useEffect, memo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  LinearProgress,
+  CircularProgress,
+  Alert,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  FormControl,
+  Checkbox,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Collapse,
+  useMediaQuery,
+  useTheme,
+  IconButton,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { useLanguage } from '../contexts/useLanguage';
+import { ImportState } from '../hooks/useImportExport';
+import { IMPORT_MODE_MERGE, IMPORT_MODE_REPLACE } from '../services/importService';
+
+/** Maximum number of sample entries to display in preview */
+const MAX_SAMPLE_ENTRIES = 5;
+
+/**
+ * Format file size to human-readable string.
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatFileSize(bytes) {
+  if (!bytes || bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+}
+
+function ImportPreviewDialog({ open, importHook, onClose }) {
+  const { t, direction } = useLanguage();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const titleRef = useRef(null);
+
+  const st = t.settings?.importExport || {};
+  const {
+    state,
+    parseResult,
+    importResult,
+    error,
+    progress,
+    executeImport,
+    reset,
+    retry,
+  } = importHook;
+
+  const [importMode, setImportMode] = useState(IMPORT_MODE_MERGE);
+  const [replaceConfirmed, setReplaceConfirmed] = useState(false);
+  const [showInvalid, setShowInvalid] = useState(false);
+
+  const isImporting = state === ImportState.IMPORTING;
+  const progressPercent = progress.total > 0
+    ? Math.round((progress.current / progress.total) * 100)
+    : 0;
+
+  // Focus management: focus title when dialog opens
+  useEffect(() => {
+    if (open && titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, [open, state]);
+
+  const handleModeChange = useCallback((event) => {
+    setImportMode(event.target.value);
+    setReplaceConfirmed(false);
+  }, []);
+
+  const handleReplaceConfirmChange = useCallback((event) => {
+    setReplaceConfirmed(event.target.checked);
+  }, []);
+
+  const handleImport = useCallback(() => {
+    executeImport(importMode);
+  }, [executeImport, importMode]);
+
+  const handleClose = useCallback(() => {
+    if (isImporting) return;
+    // Reset local state before closing
+    setImportMode(IMPORT_MODE_MERGE);
+    setReplaceConfirmed(false);
+    setShowInvalid(false);
+    reset();
+    onClose();
+  }, [isImporting, reset, onClose]);
+
+  const handleRetry = useCallback(() => {
+    retry();
+  }, [retry]);
+
+  const handleToggleInvalid = useCallback(() => {
+    setShowInvalid((prev) => !prev);
+  }, []);
+
+  const canImport = state === ImportState.PREVIEW
+    && parseResult?.validEntries?.length > 0
+    && (importMode !== IMPORT_MODE_REPLACE || replaceConfirmed);
+
+  const getTitle = () => {
+    switch (state) {
+      case ImportState.PARSING:
+        return st.importPreviewTitle || 'Import Preview';
+      case ImportState.PREVIEW:
+        return st.importPreviewTitle || 'Import Preview';
+      case ImportState.IMPORTING:
+        return st.importPreviewTitle || 'Import Preview';
+      case ImportState.SUCCESS:
+        return st.importPreviewTitle || 'Import Complete';
+      case ImportState.ERROR:
+        return st.importError || 'Import Failed';
+      default:
+        return st.importPreviewTitle || 'Import Preview';
+    }
+  };
+
+  const renderParsing = () => (
+    <DialogContent>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
+        <CircularProgress size={48} sx={{ mb: 2 }} />
+        <Typography aria-live="polite">
+          {t.loading || 'Loading...'}
+        </Typography>
+      </Box>
+    </DialogContent>
+  );
+
+  const renderPreview = () => {
+    if (!parseResult) return null;
+
+    const { filename, fileSize, validEntries, invalidEntries } = parseResult;
+    const sampleEntries = validEntries.slice(0, MAX_SAMPLE_ENTRIES);
+
+    const fileInfo = (st.importFileInfo || 'File: {filename} ({size})')
+      .replace('{filename}', filename)
+      .replace('{size}', formatFileSize(fileSize));
+
+    const validText = (st.importValidEntries || '{count} valid entries')
+      .replace('{count}', String(validEntries.length));
+
+    const invalidText = (st.importInvalidEntries || '{count} invalid entries')
+      .replace('{count}', String(invalidEntries.length));
+
+    return (
+      <DialogContent dividers>
+        {/* File info */}
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 1, unicodeBidi: 'isolate' }}
+        >
+          {fileInfo}
+        </Typography>
+
+        {/* Valid / Invalid counts */}
+        <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <CheckCircleIcon color="success" fontSize="small" />
+            <Typography variant="body2">{validText}</Typography>
+          </Box>
+          {invalidEntries.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <ErrorIcon color="error" fontSize="small" />
+              <Typography variant="body2">{invalidText}</Typography>
+              <IconButton
+                size="small"
+                onClick={handleToggleInvalid}
+                aria-label={showInvalid
+                  ? (st.importHideInvalid || 'Hide invalid entries')
+                  : (st.importShowInvalid || 'Show invalid entries')}
+                aria-expanded={showInvalid}
+              >
+                {showInvalid ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </IconButton>
+            </Box>
+          )}
+        </Box>
+
+        {/* Invalid entries expandable section */}
+        {invalidEntries.length > 0 && (
+          <Collapse in={showInvalid}>
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              {invalidEntries.slice(0, 5).map((inv, idx) => (
+                <Typography key={idx} variant="caption" component="div">
+                  Row {inv.index + 1}: {inv.errors.join(', ')}
+                </Typography>
+              ))}
+              {invalidEntries.length > 5 && (
+                <Typography variant="caption" color="text.secondary">
+                  ...and {invalidEntries.length - 5} more
+                </Typography>
+              )}
+            </Alert>
+          </Collapse>
+        )}
+
+        {/* Sample entries table */}
+        {sampleEntries.length > 0 && (
+          <TableContainer sx={{ mb: 2, maxHeight: 200, overflow: 'auto' }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t.date || 'Date'}</TableCell>
+                  <TableCell>Type</TableCell>
+                  <TableCell align="right">{t.amount || 'Amount'}</TableCell>
+                  <TableCell>{t.note || 'Note'}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sampleEntries.map((entry, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell>{entry.date}</TableCell>
+                    <TableCell>{entry.type}</TableCell>
+                    <TableCell align="right">{entry.amount}</TableCell>
+                    <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {entry.note || '-'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+
+        {/* Import mode radio group */}
+        <FormControl component="fieldset" sx={{ mb: 1 }}>
+          <RadioGroup
+            value={importMode}
+            onChange={handleModeChange}
+            aria-label={st.importTitle || 'Import mode'}
+          >
+            <FormControlLabel
+              value={IMPORT_MODE_MERGE}
+              control={<Radio />}
+              label={
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {st.importModeMerge || 'Merge (Add All)'}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {st.importModeMergeDesc || 'Add imported entries alongside existing data'}
+                  </Typography>
+                </Box>
+              }
+            />
+            <FormControlLabel
+              value={IMPORT_MODE_REPLACE}
+              control={<Radio />}
+              label={
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {st.importModeReplace || 'Replace All'}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {st.importModeReplaceDesc || 'Delete all existing data and replace with imported data'}
+                  </Typography>
+                </Box>
+              }
+            />
+          </RadioGroup>
+        </FormControl>
+
+        {/* Replace mode warning */}
+        {importMode === IMPORT_MODE_REPLACE && (
+          <Box sx={{ mt: 1 }}>
+            <Alert severity="warning" icon={<WarningAmberIcon />} sx={{ mb: 1 }}>
+              {st.importReplaceWarning || 'This will permanently delete all your existing entries!'}
+            </Alert>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              {st.importAutoBackup || 'A backup of your current data will be downloaded first'}
+            </Typography>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={replaceConfirmed}
+                  onChange={handleReplaceConfirmChange}
+                  color="warning"
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  {st.importReplaceConfirm || 'I understand, replace all my data'}
+                </Typography>
+              }
+            />
+          </Box>
+        )}
+      </DialogContent>
+    );
+  };
+
+  const renderImporting = () => (
+    <DialogContent>
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
+        <LinearProgress
+          variant="determinate"
+          value={progressPercent}
+          sx={{ width: '100%', mb: 2, height: 8, borderRadius: 4 }}
+        />
+        <Typography aria-live="polite" variant="body2">
+          {(st.importProgress || 'Importing... {current}/{total}')
+            .replace('{current}', String(progress.current))
+            .replace('{total}', String(progress.total))}
+        </Typography>
+      </Box>
+    </DialogContent>
+  );
+
+  const renderSuccess = () => (
+    <>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
+          <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 2 }} />
+          <Typography variant="h6" gutterBottom>
+            {(st.importSuccess || 'Successfully imported {count} entries')
+              .replace('{count}', String(importResult?.imported || 0))}
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleClose} variant="contained" sx={{ textTransform: 'none' }} size="large">
+          {st.cancel || t.cancel || 'Close'}
+        </Button>
+      </DialogActions>
+    </>
+  );
+
+  const renderError = () => (
+    <>
+      <DialogContent>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error || (st.importError || 'Failed to import data')}
+        </Alert>
+      </DialogContent>
+      <DialogActions sx={{ justifyContent: 'space-between', px: 3, pb: 2 }}>
+        <Button onClick={handleClose} sx={{ textTransform: 'none' }} size="large">
+          {st.cancel || t.cancel || 'Close'}
+        </Button>
+        <Button onClick={handleRetry} variant="contained" sx={{ textTransform: 'none' }} size="large">
+          {t.tryAgain || 'Try Again'}
+        </Button>
+      </DialogActions>
+    </>
+  );
+
+  const renderContent = () => {
+    switch (state) {
+      case ImportState.PARSING:
+        return renderParsing();
+      case ImportState.PREVIEW:
+        return (
+          <>
+            {renderPreview()}
+            <DialogActions sx={{ px: 3, pb: 2 }}>
+              <Button onClick={handleClose} sx={{ textTransform: 'none' }} size="large">
+                {st.cancel || t.cancel || 'Cancel'}
+              </Button>
+              <Button
+                onClick={handleImport}
+                variant="contained"
+                disabled={!canImport}
+                sx={{ textTransform: 'none' }}
+                size="large"
+              >
+                {st.import || 'Import'}
+              </Button>
+            </DialogActions>
+          </>
+        );
+      case ImportState.IMPORTING:
+        return renderImporting();
+      case ImportState.SUCCESS:
+        return renderSuccess();
+      case ImportState.ERROR:
+        return renderError();
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={isImporting ? undefined : handleClose}
+      maxWidth="sm"
+      fullWidth
+      fullScreen={isMobile}
+      dir={direction}
+      aria-labelledby="import-preview-title"
+      disableEscapeKeyDown={isImporting}
+    >
+      <DialogTitle
+        id="import-preview-title"
+        ref={titleRef}
+        tabIndex={-1}
+        sx={{ textAlign: 'center', pb: 1 }}
+      >
+        {getTitle()}
+      </DialogTitle>
+      {renderContent()}
+    </Dialog>
+  );
+}
+
+export default memo(ImportPreviewDialog);

--- a/src/components/ImportPreviewDialog.test.jsx
+++ b/src/components/ImportPreviewDialog.test.jsx
@@ -1,0 +1,450 @@
+/**
+ * ImportPreviewDialog Component Tests
+ *
+ * Tests for state machine, preview display, mode selection,
+ * replace confirmation, progress display, and accessibility.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../contexts/useLanguage', () => ({
+  useLanguage: vi.fn(),
+}));
+
+vi.mock('../services/importService', () => ({
+  IMPORT_MODE_MERGE: 'merge',
+  IMPORT_MODE_REPLACE: 'replace',
+}));
+
+vi.mock('../hooks/useImportExport', () => ({
+  ImportState: {
+    IDLE: 'idle',
+    PARSING: 'parsing',
+    PREVIEW: 'preview',
+    IMPORTING: 'importing',
+    SUCCESS: 'success',
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: null },
+  isAuthenticated: vi.fn(() => false),
+  getCurrentUserId: vi.fn(() => null),
+}));
+
+import { useLanguage } from '../contexts/useLanguage';
+import ImportPreviewDialog from './ImportPreviewDialog';
+
+const defaultTranslations = {
+  settings: {
+    importExport: {
+      importPreviewTitle: 'Import Preview',
+      importFileInfo: 'File: {filename} ({size})',
+      importValidEntries: '{count} valid entries',
+      importInvalidEntries: '{count} invalid entries',
+      importShowInvalid: 'Show invalid entries',
+      importHideInvalid: 'Hide invalid entries',
+      importModeMerge: 'Merge (Add All)',
+      importModeMergeDesc: 'Add imported entries alongside existing data',
+      importModeReplace: 'Replace All',
+      importModeReplaceDesc: 'Delete all existing data and replace with imported data',
+      importReplaceWarning: 'This will permanently delete all your existing entries!',
+      importReplaceConfirm: 'I understand, replace all my data',
+      importAutoBackup: 'A backup of your current data will be downloaded first',
+      importProgress: 'Importing... {current}/{total}',
+      importSuccess: 'Successfully imported {count} entries',
+      importError: 'Failed to import data',
+      importTitle: 'Import mode',
+      cancel: 'Cancel',
+      import: 'Import',
+    },
+  },
+  loading: 'Loading...',
+  cancel: 'Cancel',
+  tryAgain: 'Try Again',
+  date: 'Date',
+  amount: 'Amount',
+  note: 'Note',
+};
+
+function createImportHook(overrides = {}) {
+  return {
+    state: overrides.state || 'idle',
+    parseResult: overrides.parseResult || null,
+    importResult: overrides.importResult || null,
+    error: overrides.error || null,
+    progress: overrides.progress || { current: 0, total: 0, phase: '' },
+    executeImport: overrides.executeImport || vi.fn(),
+    reset: overrides.reset || vi.fn(),
+    retry: overrides.retry || vi.fn(),
+    parseFile: overrides.parseFile || vi.fn(),
+  };
+}
+
+function renderDialog(overrides = {}, languageOverrides = {}) {
+  useLanguage.mockReturnValue({
+    t: languageOverrides.t || defaultTranslations,
+    direction: languageOverrides.direction || 'ltr',
+  });
+
+  const importHook = createImportHook(overrides);
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const onClose = overrides.onClose || vi.fn();
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <ImportPreviewDialog
+        open={overrides.open ?? true}
+        importHook={importHook}
+        onClose={onClose}
+      />
+    </QueryClientProvider>
+  );
+
+  return { ...utils, importHook, onClose };
+}
+
+const sampleParseResult = {
+  filename: 'data.json',
+  fileSize: 2048,
+  validEntries: [
+    { type: 'income', date: '2026-01-15', amount: 5000, note: 'Salary' },
+    { type: 'donation', date: '2026-01-20', amount: 500, note: 'Charity' },
+    { type: 'income', date: '2026-02-15', amount: 5000, note: '' },
+  ],
+  invalidEntries: [],
+  warnings: [],
+  errors: [],
+};
+
+describe('ImportPreviewDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('closed state', () => {
+    it('should not render content when open is false', () => {
+      renderDialog({ open: false, state: 'preview', parseResult: sampleParseResult });
+      expect(screen.queryByText('Import Preview')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('parsing state', () => {
+    it('should show loading spinner during parsing', () => {
+      renderDialog({ state: 'parsing' });
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('should show dialog title as Import Preview', () => {
+      renderDialog({ state: 'parsing' });
+      expect(screen.getByText('Import Preview')).toBeInTheDocument();
+    });
+  });
+
+  describe('preview state', () => {
+    it('should show file info', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByText('File: data.json (2.0 KB)')).toBeInTheDocument();
+    });
+
+    it('should show valid entry count', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByText('3 valid entries')).toBeInTheDocument();
+    });
+
+    it('should show sample entries table', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByText('Salary')).toBeInTheDocument();
+      expect(screen.getByText('Charity')).toBeInTheDocument();
+    });
+
+    it('should show merge mode selected by default', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      const mergeRadio = screen.getByRole('radio', { name: /Merge/i });
+      expect(mergeRadio).toBeChecked();
+    });
+
+    it('should show both import mode options', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByText('Merge (Add All)')).toBeInTheDocument();
+      expect(screen.getByText('Replace All')).toBeInTheDocument();
+    });
+
+    it('should enable Import button in merge mode', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByRole('button', { name: 'Import' })).not.toBeDisabled();
+    });
+
+    it('should show Cancel button', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('should call executeImport when Import button is clicked', () => {
+      const executeImport = vi.fn();
+      renderDialog({ state: 'preview', parseResult: sampleParseResult, executeImport });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+      expect(executeImport).toHaveBeenCalledWith('merge');
+    });
+
+    it('should call onClose when Cancel button is clicked', () => {
+      const onClose = vi.fn();
+      const reset = vi.fn();
+      renderDialog({ state: 'preview', parseResult: sampleParseResult, onClose, reset });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(reset).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('invalid entries', () => {
+    const parseResultWithInvalid = {
+      ...sampleParseResult,
+      invalidEntries: [
+        { index: 3, raw: {}, errors: ['Amount is required'] },
+        { index: 5, raw: {}, errors: ['Invalid type'] },
+      ],
+    };
+
+    it('should show invalid entry count', () => {
+      renderDialog({ state: 'preview', parseResult: parseResultWithInvalid });
+      expect(screen.getByText('2 invalid entries')).toBeInTheDocument();
+    });
+
+    it('should show expand button for invalid entries', () => {
+      renderDialog({ state: 'preview', parseResult: parseResultWithInvalid });
+      expect(screen.getByLabelText('Show invalid entries')).toBeInTheDocument();
+    });
+
+    it('should not show invalid section when there are no invalid entries', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+      expect(screen.queryByLabelText('Show invalid entries')).not.toBeInTheDocument();
+    });
+
+    it('should toggle invalid entries visibility', () => {
+      renderDialog({ state: 'preview', parseResult: parseResultWithInvalid });
+
+      fireEvent.click(screen.getByLabelText('Show invalid entries'));
+      expect(screen.getByText(/Amount is required/)).toBeInTheDocument();
+    });
+  });
+
+  describe('replace mode', () => {
+    it('should show warning when replace mode is selected', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      const replaceRadio = screen.getByRole('radio', { name: /Replace/i });
+      fireEvent.click(replaceRadio);
+
+      expect(screen.getByText('This will permanently delete all your existing entries!')).toBeInTheDocument();
+    });
+
+    it('should show confirmation checkbox in replace mode', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+
+      expect(screen.getByText('I understand, replace all my data')).toBeInTheDocument();
+    });
+
+    it('should disable Import button until replace is confirmed', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+
+      expect(screen.getByRole('button', { name: 'Import' })).toBeDisabled();
+    });
+
+    it('should enable Import button after replace confirmation checkbox is checked', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+      fireEvent.click(screen.getByRole('checkbox'));
+
+      expect(screen.getByRole('button', { name: 'Import' })).not.toBeDisabled();
+    });
+
+    it('should show auto-backup notice in replace mode', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+
+      expect(screen.getByText('A backup of your current data will be downloaded first')).toBeInTheDocument();
+    });
+
+    it('should call executeImport with replace mode when confirmed and clicked', () => {
+      const executeImport = vi.fn();
+      renderDialog({ state: 'preview', parseResult: sampleParseResult, executeImport });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+      fireEvent.click(screen.getByRole('checkbox'));
+      fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+      expect(executeImport).toHaveBeenCalledWith('replace');
+    });
+  });
+
+  describe('importing state', () => {
+    it('should show progress bar during import', () => {
+      renderDialog({
+        state: 'importing',
+        progress: { current: 50, total: 100, phase: 'importing' },
+      });
+
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toBeInTheDocument();
+      expect(progressBar).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('should show progress text', () => {
+      renderDialog({
+        state: 'importing',
+        progress: { current: 50, total: 100, phase: 'importing' },
+      });
+
+      expect(screen.getByText('Importing... 50/100')).toBeInTheDocument();
+    });
+
+    it('should prevent closing during import', () => {
+      const onClose = vi.fn();
+      const reset = vi.fn();
+      renderDialog({ state: 'importing', onClose, reset });
+
+      // Dialog should have disableEscapeKeyDown
+      // The close handler should not fire
+      // We test this by checking the import hook reset is not called
+      // when the component attempts to close
+      expect(screen.getByText('Import Preview')).toBeInTheDocument();
+    });
+  });
+
+  describe('success state', () => {
+    it('should show success message with count', () => {
+      renderDialog({
+        state: 'success',
+        importResult: { imported: 42 },
+      });
+
+      // Title and body both contain the success message; verify at least one is present
+      const matches = screen.getAllByText('Successfully imported 42 entries');
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should show success icon', () => {
+      renderDialog({
+        state: 'success',
+        importResult: { imported: 10 },
+      });
+
+      expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+    });
+
+    it('should show close button in success state', () => {
+      renderDialog({
+        state: 'success',
+        importResult: { imported: 10 },
+      });
+
+      expect(screen.getByRole('button', { name: /Cancel|Close/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should show error message', () => {
+      renderDialog({
+        state: 'error',
+        error: 'Invalid JSON format',
+      });
+
+      expect(screen.getByText('Invalid JSON format')).toBeInTheDocument();
+    });
+
+    it('should show retry button', () => {
+      renderDialog({ state: 'error', error: 'Something went wrong' });
+
+      expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+    });
+
+    it('should call retry when retry button is clicked', () => {
+      const retry = vi.fn();
+      renderDialog({ state: 'error', error: 'Error', retry });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+      expect(retry).toHaveBeenCalled();
+    });
+
+    it('should show close button in error state', () => {
+      renderDialog({ state: 'error', error: 'Error' });
+
+      expect(screen.getByRole('button', { name: /Cancel|Close/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('RTL support', () => {
+    it('should pass dir prop to dialog for RTL', () => {
+      renderDialog(
+        { state: 'preview', parseResult: sampleParseResult },
+        { direction: 'rtl' }
+      );
+
+      // MUI Dialog renders dir on the Modal root wrapper, which is
+      // a parent of the role="dialog" element. Search the full document.
+      const dirElement = document.querySelector('[dir="rtl"]');
+      expect(dirElement).not.toBeNull();
+    });
+
+    it('should pass dir prop to dialog for LTR', () => {
+      renderDialog(
+        { state: 'preview', parseResult: sampleParseResult },
+        { direction: 'ltr' }
+      );
+
+      const dirElement = document.querySelector('[dir="ltr"]');
+      expect(dirElement).not.toBeNull();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have aria-labelledby on dialog', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'import-preview-title');
+    });
+
+    it('should have aria-live on progress text during import', () => {
+      renderDialog({
+        state: 'importing',
+        progress: { current: 10, total: 50, phase: 'importing' },
+      });
+
+      const liveRegion = screen.getByText('Importing... 10/50');
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should have aria-live on loading text during parsing', () => {
+      renderDialog({ state: 'parsing' });
+
+      const liveRegion = screen.getByText('Loading...');
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should have aria-label on radio group', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      const radioGroup = screen.getByRole('radiogroup');
+      expect(radioGroup).toHaveAttribute('aria-label', 'Import mode');
+    });
+  });
+});

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -1,11 +1,12 @@
 /**
  * SettingsPage Component
  *
- * Full settings page with four sections:
+ * Full settings page with five sections:
  * 1. General (language, currency)
  * 2. Ma'aser Calculation (percentage management)
  * 3. Appearance (theme toggle)
- * 4. About (version, links)
+ * 4. Data Management (import/export)
+ * 5. About (version, links)
  *
  * All settings auto-save immediately except ma'aser percentage
  * which requires confirmation via dialog.
@@ -49,6 +50,7 @@ import DarkModeIcon from '@mui/icons-material/DarkMode';
 import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
 import { useLanguage } from '../contexts/useLanguage';
 import { useSettings } from '../hooks/useSettings';
+import ImportExportSection from './ImportExportSection';
 
 const APP_VERSION = '1.2.0';
 const GITHUB_URL = 'https://github.com/DubiWork/maaser-tracker';
@@ -447,7 +449,10 @@ export default function SettingsPage({ onBack }) {
         </ToggleButtonGroup>
       </Paper>
 
-      {/* Section 4: About */}
+      {/* Section 4: Data Management (Import/Export) */}
+      <ImportExportSection />
+
+      {/* Section 5: About */}
       <Paper sx={{ p: 2 }}>
         <Typography variant="h6" component="h2" sx={{ fontWeight: 500, mb: 2 }}>
           {st.about}

--- a/src/components/SettingsPage.test.jsx
+++ b/src/components/SettingsPage.test.jsx
@@ -1,9 +1,9 @@
 /**
  * Tests for SettingsPage and SettingsButton components
  *
- * Covers all four sections (General, Ma'aser Calculation, Appearance, About),
- * navigation, auto-save pattern, confirmation dialog, percentage history,
- * bilingual support, and accessibility.
+ * Covers all five sections (General, Ma'aser Calculation, Appearance,
+ * Data Management, About), navigation, auto-save pattern, confirmation dialog,
+ * percentage history, bilingual support, and accessibility.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -13,6 +13,11 @@ import { LanguageProvider } from '../contexts/LanguageProvider';
 import { SettingsProvider } from '../contexts/SettingsProvider';
 import SettingsPage from './SettingsPage';
 import SettingsButton from './SettingsButton';
+
+// Mock ImportExportSection since it has its own test suite
+vi.mock('./ImportExportSection', () => ({
+  default: () => <div data-testid="import-export-section"><h2>Data Management</h2></div>,
+}));
 
 // Mock IndexedDB settings service
 vi.mock('../services/settingsDb', () => ({
@@ -589,7 +594,7 @@ describe('SettingsPage', () => {
 
       // h2: Section headings
       const h2s = screen.getAllByRole('heading', { level: 2 });
-      expect(h2s.length).toBe(4);
+      expect(h2s.length).toBe(5);
     });
 
     it('should have aria-label on back button', async () => {

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -373,6 +373,48 @@ const translations = {
       // Confirmation dialogs
       areYouSure: 'האם אתה בטוח?',
       confirm: 'אישור',
+
+      // Import/Export (local data backup & restore)
+      importExport: {
+        sectionTitle: 'ניהול נתונים',
+        sectionDescription: 'גיבוי, שחזור או העברת הנתונים שלך',
+        // Export
+        exportTitle: 'ייצוא נתונים',
+        exportJSON: 'ייצוא JSON',
+        exportCSV: 'ייצוא CSV',
+        exportSuccess: 'הנתונים יוצאו בהצלחה',
+        exportError: 'ייצוא הנתונים נכשל',
+        exportEmpty: 'אין רשומות לייצוא',
+        exportSecurityWarning: 'קובץ זה מכיל את הנתונים הפיננסיים שלך. שמור אותו במקום בטוח.',
+        // Import
+        importTitle: 'ייבוא נתונים',
+        importButton: 'ייבוא מקובץ',
+        importPreviewTitle: 'תצוגה מקדימה של ייבוא',
+        importFileInfo: 'קובץ: {filename} ({size})',
+        importValidEntries: '{count} רשומות תקינות',
+        importInvalidEntries: '{count} רשומות לא תקינות',
+        importShowInvalid: 'הצג רשומות לא תקינות',
+        importHideInvalid: 'הסתר רשומות לא תקינות',
+        // Conflict modes
+        importModeMerge: 'מיזוג (הוסף הכל)',
+        importModeMergeDesc: 'הוסף רשומות מיובאות לצד הנתונים הקיימים',
+        importModeReplace: 'החלף הכל',
+        importModeReplaceDesc: 'מחק את כל הנתונים הקיימים והחלף בנתונים המיובאים',
+        importReplaceWarning: 'פעולה זו תמחק לצמיתות את כל הרשומות הקיימות שלך!',
+        importReplaceConfirm: 'אני מבין/ה, החלף את כל הנתונים שלי',
+        importAutoBackup: 'גיבוי של הנתונים הנוכחיים שלך יורד תחילה',
+        // Progress & results
+        importProgress: 'מייבא... {current}/{total}',
+        importSuccess: '{count} רשומות יובאו בהצלחה',
+        importError: 'ייבוא הנתונים נכשל',
+        importInvalidFile: 'פורמט קובץ לא חוקי. אנא בחר קובץ JSON או CSV.',
+        importFileTooLarge: 'הקובץ גדול מדי (מקסימום 10 MB)',
+        importFileSizeWarning: 'קובץ גדול ({size}). הייבוא עשוי לקחת רגע.',
+        // Common
+        iosSaveHint: 'הקש על סמל השיתוף כדי לשמור את הקובץ',
+        cancel: 'ביטול',
+        import: 'ייבוא',
+      },
     },
   },
   en: {
@@ -734,6 +776,48 @@ const translations = {
       // Confirmation dialogs
       areYouSure: 'Are you sure?',
       confirm: 'Confirm',
+
+      // Import/Export (local data backup & restore)
+      importExport: {
+        sectionTitle: 'Data Management',
+        sectionDescription: 'Backup, restore, or transfer your data',
+        // Export
+        exportTitle: 'Export Data',
+        exportJSON: 'Export JSON',
+        exportCSV: 'Export CSV',
+        exportSuccess: 'Data exported successfully',
+        exportError: 'Failed to export data',
+        exportEmpty: 'No entries to export',
+        exportSecurityWarning: 'This file contains your financial data. Store it securely.',
+        // Import
+        importTitle: 'Import Data',
+        importButton: 'Import from File',
+        importPreviewTitle: 'Import Preview',
+        importFileInfo: 'File: {filename} ({size})',
+        importValidEntries: '{count} valid entries',
+        importInvalidEntries: '{count} invalid entries',
+        importShowInvalid: 'Show invalid entries',
+        importHideInvalid: 'Hide invalid entries',
+        // Conflict modes
+        importModeMerge: 'Merge (Add All)',
+        importModeMergeDesc: 'Add imported entries alongside existing data',
+        importModeReplace: 'Replace All',
+        importModeReplaceDesc: 'Delete all existing data and replace with imported data',
+        importReplaceWarning: 'This will permanently delete all your existing entries!',
+        importReplaceConfirm: 'I understand, replace all my data',
+        importAutoBackup: 'A backup of your current data will be downloaded first',
+        // Progress & results
+        importProgress: 'Importing... {current}/{total}',
+        importSuccess: 'Successfully imported {count} entries',
+        importError: 'Failed to import data',
+        importInvalidFile: 'Invalid file format. Please select a JSON or CSV file.',
+        importFileTooLarge: 'File is too large (max 10 MB)',
+        importFileSizeWarning: 'Large file ({size}). Import may take a moment.',
+        // Common
+        iosSaveHint: 'Tap the share icon to save the file',
+        cancel: 'Cancel',
+        import: 'Import',
+      },
     },
   },
 };

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -70,6 +70,8 @@ const EXPECTED_SETTINGS_KEYS = [
   // Confirmation dialogs
   'areYouSure',
   'confirm',
+  // Import/Export (nested object)
+  'importExport',
 ];
 
 /**
@@ -126,9 +128,10 @@ describe('Settings Translation Keys', () => {
       }
     });
 
-    it('should have non-empty string values for all keys', () => {
+    it('should have non-empty string values for all flat keys', () => {
       for (const key of EXPECTED_SETTINGS_KEYS) {
         const value = heSettings[key];
+        if (typeof value === 'object') continue; // Skip nested objects (e.g., importExport)
         expect(typeof value).toBe('string');
         expect(value.trim().length).toBeGreaterThan(0);
       }
@@ -155,9 +158,10 @@ describe('Settings Translation Keys', () => {
       }
     });
 
-    it('should have non-empty string values for all keys', () => {
+    it('should have non-empty string values for all flat keys', () => {
       for (const key of EXPECTED_SETTINGS_KEYS) {
         const value = enSettings[key];
+        if (typeof value === 'object') continue; // Skip nested objects (e.g., importExport)
         expect(typeof value).toBe('string');
         expect(value.trim().length).toBeGreaterThan(0);
       }
@@ -196,10 +200,11 @@ describe('Settings Translation Keys', () => {
       expect(Object.keys(heSettings).length).toBe(Object.keys(enSettings).length);
     });
 
-    it('should have different values between languages for all keys', () => {
+    it('should have different values between languages for all flat keys', () => {
       // Every key should have a different value in Hebrew vs English
       // (they are different languages, so values should differ)
       for (const key of EXPECTED_SETTINGS_KEYS) {
+        if (typeof heSettings[key] === 'object') continue; // Skip nested objects
         expect(heSettings[key]).not.toBe(enSettings[key]);
       }
     });
@@ -279,6 +284,116 @@ describe('Settings Translation Keys', () => {
     it('should have the expected number of settings keys', () => {
       expect(Object.keys(heSettings).length).toBe(EXPECTED_SETTINGS_KEYS.length);
       expect(Object.keys(enSettings).length).toBe(EXPECTED_SETTINGS_KEYS.length);
+    });
+  });
+
+  describe('Import/Export translations (settings.importExport)', () => {
+    const EXPECTED_IMPORT_EXPORT_KEYS = [
+      'sectionTitle',
+      'sectionDescription',
+      'exportTitle',
+      'exportJSON',
+      'exportCSV',
+      'exportSuccess',
+      'exportError',
+      'exportEmpty',
+      'exportSecurityWarning',
+      'importTitle',
+      'importButton',
+      'importPreviewTitle',
+      'importFileInfo',
+      'importValidEntries',
+      'importInvalidEntries',
+      'importShowInvalid',
+      'importHideInvalid',
+      'importModeMerge',
+      'importModeMergeDesc',
+      'importModeReplace',
+      'importModeReplaceDesc',
+      'importReplaceWarning',
+      'importReplaceConfirm',
+      'importAutoBackup',
+      'importProgress',
+      'importSuccess',
+      'importError',
+      'importInvalidFile',
+      'importFileTooLarge',
+      'importFileSizeWarning',
+      'iosSaveHint',
+      'cancel',
+      'import',
+    ];
+
+    it('should have importExport as a nested object in both languages', () => {
+      expect(typeof heSettings.importExport).toBe('object');
+      expect(typeof enSettings.importExport).toBe('object');
+    });
+
+    it('should contain all expected import/export keys in Hebrew', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(heSettings.importExport).toHaveProperty(key);
+      }
+    });
+
+    it('should contain all expected import/export keys in English', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(enSettings.importExport).toHaveProperty(key);
+      }
+    });
+
+    it('should have identical key sets in both languages', () => {
+      const heKeys = Object.keys(heSettings.importExport).sort();
+      const enKeys = Object.keys(enSettings.importExport).sort();
+      expect(heKeys).toEqual(enKeys);
+    });
+
+    it('should have the expected number of import/export keys', () => {
+      expect(Object.keys(heSettings.importExport).length).toBe(EXPECTED_IMPORT_EXPORT_KEYS.length);
+      expect(Object.keys(enSettings.importExport).length).toBe(EXPECTED_IMPORT_EXPORT_KEYS.length);
+    });
+
+    it('should have non-empty string values for all import/export keys', () => {
+      for (const key of EXPECTED_IMPORT_EXPORT_KEYS) {
+        expect(typeof heSettings.importExport[key]).toBe('string');
+        expect(heSettings.importExport[key].trim().length).toBeGreaterThan(0);
+        expect(typeof enSettings.importExport[key]).toBe('string');
+        expect(enSettings.importExport[key].trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have proper Hebrew content for import/export keys', () => {
+      expect(heSettings.importExport.sectionTitle).toBe('ניהול נתונים');
+      expect(heSettings.importExport.exportTitle).toBe('ייצוא נתונים');
+      expect(heSettings.importExport.importTitle).toBe('ייבוא נתונים');
+    });
+
+    it('should have proper English content for import/export keys', () => {
+      expect(enSettings.importExport.sectionTitle).toBe('Data Management');
+      expect(enSettings.importExport.exportTitle).toBe('Export Data');
+      expect(enSettings.importExport.importTitle).toBe('Import Data');
+    });
+
+    it('should have matching template placeholders in both languages', () => {
+      const templateKeys = [
+        'importFileInfo',
+        'importValidEntries',
+        'importInvalidEntries',
+        'importProgress',
+        'importSuccess',
+        'importFileSizeWarning',
+      ];
+
+      for (const key of templateKeys) {
+        const hePlaceholders = (heSettings.importExport[key].match(/\{[^}]+\}/g) || []).sort();
+        const enPlaceholders = (enSettings.importExport[key].match(/\{[^}]+\}/g) || []).sort();
+        expect(hePlaceholders).toEqual(enPlaceholders);
+      }
+    });
+
+    it('should be separate from dataManagement namespace', () => {
+      // Verify importExport keys do not collide with top-level dataManagement keys
+      expect(heSettings.importExport).not.toBe(heSettings.dataManagement);
+      expect(enSettings.importExport).not.toBe(enSettings.dataManagement);
     });
   });
 });

--- a/src/hooks/useImportExport.js
+++ b/src/hooks/useImportExport.js
@@ -1,0 +1,237 @@
+/**
+ * useImportExport Hook
+ *
+ * Provides React Query mutations for export (JSON/CSV) and import operations.
+ * Connects UI components to exportService and importService.
+ *
+ * Export hooks read entries via useEntries and trigger file downloads.
+ * Import hook manages a state machine: IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR.
+ * Cache invalidation is performed after every successful import.
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEntries, queryKeys } from './useEntries';
+import { exportToJSON, exportToCSV, downloadFile, generateFilename } from '../services/exportService';
+import {
+  parseJSONFile,
+  parseCSVFile,
+  importEntries,
+  IMPORT_MODE_MERGE,
+  IMPORT_MODE_REPLACE,
+} from '../services/importService';
+
+/** Import state machine states */
+export const ImportState = {
+  IDLE: 'idle',
+  PARSING: 'parsing',
+  PREVIEW: 'preview',
+  IMPORTING: 'importing',
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+/**
+ * Hook for exporting entries as JSON.
+ *
+ * @returns {{ exportJSON: Function, isExporting: boolean, error: string|null, isIOS: boolean, reset: Function }}
+ */
+export function useExportJSON() {
+  const { data: entries } = useEntries();
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState(null);
+  const [isIOS, setIsIOS] = useState(false);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setIsIOS(false);
+  }, []);
+
+  const exportJSON = useCallback(async () => {
+    setIsExporting(true);
+    setError(null);
+    setIsIOS(false);
+
+    try {
+      if (!entries || entries.length === 0) {
+        throw new Error('No entries to export');
+      }
+
+      const json = exportToJSON(entries);
+      const filename = generateFilename('json');
+      const result = downloadFile(json, filename, 'application/json');
+      setIsIOS(result.iosSafari);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [entries]);
+
+  return { exportJSON, isExporting, error, isIOS, reset };
+}
+
+/**
+ * Hook for exporting entries as CSV.
+ *
+ * @returns {{ exportCSV: Function, isExporting: boolean, error: string|null, isIOS: boolean, reset: Function }}
+ */
+export function useExportCSV() {
+  const { data: entries } = useEntries();
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState(null);
+  const [isIOS, setIsIOS] = useState(false);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setIsIOS(false);
+  }, []);
+
+  const exportCSV = useCallback(async () => {
+    setIsExporting(true);
+    setError(null);
+    setIsIOS(false);
+
+    try {
+      if (!entries || entries.length === 0) {
+        throw new Error('No entries to export');
+      }
+
+      const csv = await exportToCSV(entries);
+      const filename = generateFilename('csv');
+      const result = downloadFile(csv, filename, 'text/csv;charset=utf-8');
+      setIsIOS(result.iosSafari);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [entries]);
+
+  return { exportCSV, isExporting, error, isIOS, reset };
+}
+
+/**
+ * Hook for importing entries from a file.
+ *
+ * Manages the import state machine:
+ *   IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ *
+ * @returns {Object} Import state and control functions
+ */
+export function useImport() {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState(ImportState.IDLE);
+  const [parseResult, setParseResult] = useState(null);
+  const [importResult, setImportResult] = useState(null);
+  const [error, setError] = useState(null);
+  const [progress, setProgress] = useState({ current: 0, total: 0, phase: '' });
+  const fileRef = useRef(null);
+
+  /**
+   * Parse a file and transition to PREVIEW state.
+   * @param {File} file - File to parse
+   */
+  const parseFile = useCallback(async (file) => {
+    if (!file) return;
+
+    fileRef.current = file;
+    setState(ImportState.PARSING);
+    setError(null);
+    setParseResult(null);
+    setImportResult(null);
+
+    try {
+      const isCSV = file.name.toLowerCase().endsWith('.csv');
+      const result = isCSV ? await parseCSVFile(file) : await parseJSONFile(file);
+
+      // If there are file-level errors AND no valid entries, treat as error
+      if (result.validEntries.length === 0 && result.errors.length > 0) {
+        setState(ImportState.ERROR);
+        setError(result.errors[0]);
+        return;
+      }
+
+      setParseResult({
+        filename: file.name,
+        fileSize: file.size,
+        validEntries: result.validEntries,
+        invalidEntries: result.invalidEntries,
+        warnings: result.warnings,
+        errors: result.errors,
+      });
+      setState(ImportState.PREVIEW);
+    } catch (err) {
+      setState(ImportState.ERROR);
+      setError(err.message || 'Failed to parse file');
+    }
+  }, []);
+
+  /**
+   * Execute the import with the given mode.
+   * @param {string} mode - 'merge' or 'replace'
+   */
+  const executeImport = useCallback(async (mode = IMPORT_MODE_MERGE) => {
+    if (!parseResult || parseResult.validEntries.length === 0) return;
+
+    setState(ImportState.IMPORTING);
+    setProgress({ current: 0, total: parseResult.validEntries.length, phase: 'starting' });
+
+    try {
+      const result = await importEntries(
+        parseResult.validEntries,
+        mode,
+        {
+          onProgress: (p) => setProgress(p),
+          skipBackup: mode !== IMPORT_MODE_REPLACE ? true : false,
+        }
+      );
+
+      if (result.success) {
+        setImportResult(result);
+        setState(ImportState.SUCCESS);
+        // Invalidate entries cache so UI refreshes
+        await queryClient.invalidateQueries({ queryKey: queryKeys.all });
+      } else {
+        setState(ImportState.ERROR);
+        setError(result.errors?.[0] || 'Import failed');
+      }
+    } catch (err) {
+      setState(ImportState.ERROR);
+      setError(err.message || 'Import failed');
+    }
+  }, [parseResult, queryClient]);
+
+  /**
+   * Reset the import state machine back to IDLE.
+   */
+  const reset = useCallback(() => {
+    setState(ImportState.IDLE);
+    setParseResult(null);
+    setImportResult(null);
+    setError(null);
+    setProgress({ current: 0, total: 0, phase: '' });
+    fileRef.current = null;
+  }, []);
+
+  /**
+   * Retry parsing the last file after an error.
+   */
+  const retry = useCallback(() => {
+    if (fileRef.current) {
+      parseFile(fileRef.current);
+    }
+  }, [parseFile]);
+
+  return {
+    state,
+    parseResult,
+    importResult,
+    error,
+    progress,
+    parseFile,
+    executeImport,
+    reset,
+    retry,
+  };
+}

--- a/src/hooks/useImportExport.test.jsx
+++ b/src/hooks/useImportExport.test.jsx
@@ -1,0 +1,522 @@
+/**
+ * useImportExport Hook Tests
+ *
+ * Tests for useExportJSON, useExportCSV, and useImport hooks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Mock services before imports
+vi.mock('../services/exportService', () => ({
+  exportToJSON: vi.fn(),
+  exportToCSV: vi.fn(),
+  downloadFile: vi.fn(),
+  generateFilename: vi.fn(),
+}));
+
+vi.mock('../services/importService', () => ({
+  parseJSONFile: vi.fn(),
+  parseCSVFile: vi.fn(),
+  importEntries: vi.fn(),
+  IMPORT_MODE_MERGE: 'merge',
+  IMPORT_MODE_REPLACE: 'replace',
+}));
+
+vi.mock('./useEntries', () => ({
+  useEntries: vi.fn(),
+  queryKeys: {
+    all: ['entries'],
+    lists: () => ['entries', 'list'],
+    list: (f) => ['entries', 'list', f],
+    details: () => ['entries', 'detail'],
+    detail: (id) => ['entries', 'detail', id],
+    migrationStatus: (uid) => ['migration', 'status', uid],
+  },
+  useMigrationStatus: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock('../lib/firebase', () => ({
+  db: {},
+  auth: { currentUser: null },
+  isAuthenticated: vi.fn(() => false),
+  getCurrentUserId: vi.fn(() => null),
+}));
+
+import { useExportJSON, useExportCSV, useImport, ImportState } from './useImportExport';
+import { exportToJSON, exportToCSV, downloadFile, generateFilename } from '../services/exportService';
+import { parseJSONFile, parseCSVFile, importEntries } from '../services/importService';
+import { useEntries } from './useEntries';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const mockEntries = [
+  { id: '1', type: 'income', date: '2026-01-15', amount: 5000, note: 'Salary' },
+  { id: '2', type: 'donation', date: '2026-01-20', amount: 500, note: 'Charity' },
+];
+
+describe('useExportJSON', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEntries.mockReturnValue({ data: mockEntries });
+    exportToJSON.mockReturnValue('{"test":"json"}');
+    generateFilename.mockReturnValue('maaser-tracker-2026-03-09.json');
+    downloadFile.mockReturnValue({ downloaded: true, iosSafari: false });
+  });
+
+  it('should export entries as JSON and trigger download', async () => {
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+
+    expect(exportToJSON).toHaveBeenCalledWith(mockEntries);
+    expect(downloadFile).toHaveBeenCalledWith('{"test":"json"}', 'maaser-tracker-2026-03-09.json', 'application/json');
+    expect(result.current.error).toBeNull();
+    expect(result.current.isExporting).toBe(false);
+  });
+
+  it('should set error when no entries exist', async () => {
+    useEntries.mockReturnValue({ data: [] });
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+
+    expect(result.current.error).toBe('No entries to export');
+    expect(exportToJSON).not.toHaveBeenCalled();
+  });
+
+  it('should set error when entries are null', async () => {
+    useEntries.mockReturnValue({ data: null });
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+
+    expect(result.current.error).toBe('No entries to export');
+  });
+
+  it('should detect iOS Safari download', async () => {
+    downloadFile.mockReturnValue({ downloaded: true, iosSafari: true });
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+
+    expect(result.current.isIOS).toBe(true);
+  });
+
+  it('should handle export service errors', async () => {
+    exportToJSON.mockImplementation(() => { throw new Error('JSON serialize failed'); });
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+
+    expect(result.current.error).toBe('JSON serialize failed');
+  });
+
+  it('should reset error state via reset()', async () => {
+    useEntries.mockReturnValue({ data: [] });
+    const { result } = renderHook(() => useExportJSON(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportJSON();
+    });
+    expect(result.current.error).toBe('No entries to export');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe('useExportCSV', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEntries.mockReturnValue({ data: mockEntries });
+    exportToCSV.mockResolvedValue('csv,content');
+    generateFilename.mockReturnValue('maaser-tracker-2026-03-09.csv');
+    downloadFile.mockReturnValue({ downloaded: true, iosSafari: false });
+  });
+
+  it('should export entries as CSV and trigger download', async () => {
+    const { result } = renderHook(() => useExportCSV(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportCSV();
+    });
+
+    expect(exportToCSV).toHaveBeenCalledWith(mockEntries);
+    expect(downloadFile).toHaveBeenCalledWith('csv,content', 'maaser-tracker-2026-03-09.csv', 'text/csv;charset=utf-8');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should set error when no entries exist', async () => {
+    useEntries.mockReturnValue({ data: [] });
+    const { result } = renderHook(() => useExportCSV(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportCSV();
+    });
+
+    expect(result.current.error).toBe('No entries to export');
+    expect(exportToCSV).not.toHaveBeenCalled();
+  });
+
+  it('should handle CSV export errors', async () => {
+    exportToCSV.mockRejectedValue(new Error('PapaParse failed'));
+    const { result } = renderHook(() => useExportCSV(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportCSV();
+    });
+
+    expect(result.current.error).toBe('PapaParse failed');
+  });
+
+  it('should detect iOS Safari for CSV download', async () => {
+    downloadFile.mockReturnValue({ downloaded: true, iosSafari: true });
+    const { result } = renderHook(() => useExportCSV(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportCSV();
+    });
+
+    expect(result.current.isIOS).toBe(true);
+  });
+});
+
+describe('useImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should start in IDLE state', () => {
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(result.current.parseResult).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should parse a JSON file and transition to PREVIEW', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+    expect(result.current.parseResult).not.toBeNull();
+    expect(result.current.parseResult.validEntries).toHaveLength(1);
+    expect(result.current.parseResult.filename).toBe('data.json');
+  });
+
+  it('should parse a CSV file and transition to PREVIEW', async () => {
+    parseCSVFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File([''], 'data.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(parseCSVFile).toHaveBeenCalledWith(mockFile);
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+  });
+
+  it('should transition to ERROR when no valid entries', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [],
+      invalidEntries: [],
+      errors: ['Invalid JSON format'],
+      warnings: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['bad'], 'data.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('Invalid JSON format');
+  });
+
+  it('should transition to ERROR on parse exception', async () => {
+    parseJSONFile.mockRejectedValue(new Error('File read failed'));
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File([''], 'data.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('File read failed');
+  });
+
+  it('should execute import in merge mode successfully', async () => {
+    const validEntries = [
+      { type: 'income', date: '2026-01-15', amount: 5000 },
+      { type: 'donation', date: '2026-01-20', amount: 500 },
+    ];
+
+    parseJSONFile.mockResolvedValue({
+      validEntries,
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    importEntries.mockResolvedValue({
+      success: true,
+      mode: 'merge',
+      imported: 2,
+      backedUp: 0,
+      failed: [],
+      errors: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+
+    await act(async () => {
+      await result.current.executeImport('merge');
+    });
+
+    expect(result.current.state).toBe(ImportState.SUCCESS);
+    expect(result.current.importResult.imported).toBe(2);
+  });
+
+  it('should execute import in replace mode', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    importEntries.mockResolvedValue({
+      success: true,
+      mode: 'replace',
+      imported: 1,
+      backedUp: 3,
+      failed: [],
+      errors: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    await act(async () => {
+      await result.current.executeImport('replace');
+    });
+
+    expect(result.current.state).toBe(ImportState.SUCCESS);
+    expect(importEntries).toHaveBeenCalledWith(
+      expect.any(Array),
+      'replace',
+      expect.objectContaining({ skipBackup: false })
+    );
+  });
+
+  it('should transition to ERROR on import failure', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    importEntries.mockResolvedValue({
+      success: false,
+      mode: 'merge',
+      imported: 0,
+      backedUp: 0,
+      failed: [],
+      errors: ['Failed to write entry'],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    await act(async () => {
+      await result.current.executeImport('merge');
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('Failed to write entry');
+  });
+
+  it('should transition to ERROR on import exception', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    importEntries.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    await act(async () => {
+      await result.current.executeImport('merge');
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('Network error');
+  });
+
+  it('should reset all state back to IDLE', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [],
+      errors: [],
+      warnings: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(result.current.parseResult).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.importResult).toBeNull();
+  });
+
+  it('should retry parsing the last file', async () => {
+    parseJSONFile
+      .mockRejectedValueOnce(new Error('First attempt failed'))
+      .mockResolvedValueOnce({
+        validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+        invalidEntries: [],
+        errors: [],
+        warnings: [],
+      });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['{}'], 'data.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+    expect(result.current.state).toBe(ImportState.ERROR);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+  });
+
+  it('should not parse when file is null', async () => {
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.parseFile(null);
+    });
+
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(parseJSONFile).not.toHaveBeenCalled();
+    expect(parseCSVFile).not.toHaveBeenCalled();
+  });
+
+  it('should not execute import when no parse result', async () => {
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.executeImport('merge');
+    });
+
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(importEntries).not.toHaveBeenCalled();
+  });
+
+  it('should include file metadata in parse result', async () => {
+    parseJSONFile.mockResolvedValue({
+      validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
+      invalidEntries: [{ index: 1, raw: {}, errors: ['bad'] }],
+      errors: [],
+      warnings: ['File is large'],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['x'.repeat(1000)], 'test.json', { type: 'application/json' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.parseResult.filename).toBe('test.json');
+    expect(result.current.parseResult.fileSize).toBe(1000);
+    expect(result.current.parseResult.invalidEntries).toHaveLength(1);
+    expect(result.current.parseResult.warnings).toContain('File is large');
+  });
+});

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -1,0 +1,374 @@
+/**
+ * Export Service Tests
+ *
+ * Unit tests for JSON/CSV export, filename generation, download trigger,
+ * field stripping, and CSV formula injection prevention.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  exportToJSON,
+  exportToCSV,
+  downloadFile,
+  generateFilename,
+} from '../exportService';
+
+// --- Test fixtures ---
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'entry-1',
+    type: 'income',
+    date: '2026-03-01',
+    amount: 5000,
+    note: 'Salary',
+    accountingMonth: '2026-03',
+    ...overrides,
+  };
+}
+
+function makeEntryWithInternalFields(overrides = {}) {
+  return {
+    ...makeEntry(),
+    createdAt: '2026-03-01T10:00:00.000Z',
+    updatedAt: '2026-03-01T11:00:00.000Z',
+    userId: 'user-123',
+    ...overrides,
+  };
+}
+
+// --- generateFilename ---
+
+describe('generateFilename', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should generate JSON filename with current date', () => {
+    vi.setSystemTime(new Date('2026-03-15'));
+    expect(generateFilename('json')).toBe('maaser-tracker-2026-03-15.json');
+  });
+
+  it('should generate CSV filename with current date', () => {
+    vi.setSystemTime(new Date('2026-03-15'));
+    expect(generateFilename('csv')).toBe('maaser-tracker-2026-03-15.csv');
+  });
+
+  it('should pad single-digit month and day', () => {
+    vi.setSystemTime(new Date('2026-01-05'));
+    expect(generateFilename('json')).toBe('maaser-tracker-2026-01-05.json');
+  });
+
+  it('should handle end of year dates', () => {
+    vi.setSystemTime(new Date('2026-12-31'));
+    expect(generateFilename('csv')).toBe('maaser-tracker-2026-12-31.csv');
+  });
+});
+
+// --- exportToJSON ---
+
+describe('exportToJSON', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should produce valid JSON with schema v1 envelope', () => {
+    const entries = [makeEntry()];
+    const result = exportToJSON(entries);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.exportDate).toBe('2026-03-15T12:00:00.000Z');
+    expect(parsed.entryCount).toBe(1);
+    expect(parsed.entries).toHaveLength(1);
+  });
+
+  it('should include all user-facing entry fields', () => {
+    const entries = [makeEntry()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    const entry = parsed.entries[0];
+
+    expect(entry.id).toBe('entry-1');
+    expect(entry.type).toBe('income');
+    expect(entry.date).toBe('2026-03-01');
+    expect(entry.amount).toBe(5000);
+    expect(entry.note).toBe('Salary');
+    expect(entry.accountingMonth).toBe('2026-03');
+  });
+
+  it('should strip createdAt from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('createdAt');
+  });
+
+  it('should strip updatedAt from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('updatedAt');
+  });
+
+  it('should strip userId from exported entries', () => {
+    const entries = [makeEntryWithInternalFields()];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0]).not.toHaveProperty('userId');
+  });
+
+  it('should handle multiple entries', () => {
+    const entries = [
+      makeEntry({ id: 'entry-1', amount: 5000 }),
+      makeEntry({ id: 'entry-2', type: 'donation', amount: 500 }),
+      makeEntry({ id: 'entry-3', amount: 3000 }),
+    ];
+    const parsed = JSON.parse(exportToJSON(entries));
+
+    expect(parsed.entryCount).toBe(3);
+    expect(parsed.entries).toHaveLength(3);
+    expect(parsed.entries[1].type).toBe('donation');
+  });
+
+  it('should produce pretty-printed JSON (2-space indentation)', () => {
+    const entries = [makeEntry()];
+    const result = exportToJSON(entries);
+    // Pretty-printed JSON contains newlines
+    expect(result).toContain('\n');
+    expect(result).toContain('  ');
+  });
+
+  it('should throw if entries is empty array', () => {
+    expect(() => exportToJSON([])).toThrow('No entries to export');
+  });
+
+  it('should throw if entries is not an array', () => {
+    expect(() => exportToJSON(null)).toThrow('No entries to export');
+    expect(() => exportToJSON(undefined)).toThrow('No entries to export');
+    expect(() => exportToJSON('string')).toThrow('No entries to export');
+    expect(() => exportToJSON(42)).toThrow('No entries to export');
+  });
+
+  it('should not mutate original entries', () => {
+    const original = makeEntryWithInternalFields();
+    const entries = [original];
+    exportToJSON(entries);
+
+    expect(original).toHaveProperty('createdAt');
+    expect(original).toHaveProperty('updatedAt');
+    expect(original).toHaveProperty('userId');
+  });
+
+  it('should handle entries without optional fields', () => {
+    const entry = { id: 'e1', type: 'income', date: '2026-01-01', amount: 100 };
+    const parsed = JSON.parse(exportToJSON([entry]));
+
+    expect(parsed.entries[0].id).toBe('e1');
+    expect(parsed.entries[0]).not.toHaveProperty('note');
+  });
+});
+
+// --- exportToCSV ---
+
+describe('exportToCSV', () => {
+  it('should produce CSV with UTF-8 BOM prefix', async () => {
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    expect(result.charCodeAt(0)).toBe(0xFEFF);
+  });
+
+  it('should include English column headers', async () => {
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    const firstLine = result.replace('\uFEFF', '').split('\n')[0];
+    expect(firstLine).toContain('id');
+    expect(firstLine).toContain('type');
+    expect(firstLine).toContain('date');
+    expect(firstLine).toContain('amount');
+    expect(firstLine).toContain('note');
+    expect(firstLine).toContain('accountingMonth');
+  });
+
+  it('should include entry data in CSV output', async () => {
+    const entries = [makeEntry({ id: 'test-id', amount: 1234 })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('test-id');
+    expect(result).toContain('1234');
+  });
+
+  it('should handle multiple entries', async () => {
+    const entries = [
+      makeEntry({ id: 'e1' }),
+      makeEntry({ id: 'e2', type: 'donation' }),
+    ];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('e1');
+    expect(result).toContain('e2');
+  });
+
+  it('should strip internal fields from CSV export', async () => {
+    const entries = [makeEntryWithInternalFields()];
+    const result = await exportToCSV(entries);
+    expect(result).not.toContain('createdAt');
+    expect(result).not.toContain('updatedAt');
+    expect(result).not.toContain('userId');
+  });
+
+  it('should sanitize cells starting with = to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '=SUM(A1:A10)' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'=SUM(A1:A10)");
+  });
+
+  it('should sanitize cells starting with + to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '+cmd|calc' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'+cmd|calc");
+  });
+
+  it('should sanitize cells starting with - to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '-1+1' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'-1+1");
+  });
+
+  it('should sanitize cells starting with @ to prevent formula injection', async () => {
+    const entries = [makeEntry({ note: '@SUM(A1)' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain("'@SUM(A1)");
+  });
+
+  it('should not sanitize normal text values', async () => {
+    const entries = [makeEntry({ note: 'Normal salary payment' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('Normal salary payment');
+    // Should not have a leading quote
+    expect(result).not.toContain("'Normal salary payment");
+  });
+
+  it('should throw if entries is empty array', async () => {
+    await expect(exportToCSV([])).rejects.toThrow('No entries to export');
+  });
+
+  it('should throw if entries is not an array', async () => {
+    await expect(exportToCSV(null)).rejects.toThrow('No entries to export');
+    await expect(exportToCSV(undefined)).rejects.toThrow('No entries to export');
+  });
+
+  it('should load PapaParse via dynamic import', async () => {
+    // PapaParse is loaded dynamically — the test succeeds only if the import works
+    const entries = [makeEntry()];
+    const result = await exportToCSV(entries);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('should handle entries with Hebrew text', async () => {
+    const entries = [makeEntry({ note: 'משכורת חודשית' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('משכורת חודשית');
+  });
+});
+
+// --- downloadFile ---
+
+describe('downloadFile', () => {
+  let createObjectURLMock;
+  let revokeObjectURLMock;
+  let appendChildSpy;
+  let removeChildSpy;
+  let clickSpy;
+
+  beforeEach(() => {
+    createObjectURLMock = vi.fn().mockReturnValue('blob:mock-url');
+    revokeObjectURLMock = vi.fn();
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+
+    clickSpy = vi.fn();
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+    removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        return {
+          href: '',
+          download: '',
+          style: {},
+          click: clickSpy,
+        };
+      }
+      return document.createElement(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create a Blob with the correct content and MIME type', () => {
+    downloadFile('test content', 'test.json', 'application/json');
+    expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  it('should set anchor download attribute to filename', () => {
+    let capturedAnchor;
+    document.createElement.mockImplementation((tag) => {
+      if (tag === 'a') {
+        capturedAnchor = { href: '', download: '', style: {}, click: clickSpy };
+        return capturedAnchor;
+      }
+    });
+
+    downloadFile('data', 'myfile.csv', 'text/csv');
+    expect(capturedAnchor.download).toBe('myfile.csv');
+  });
+
+  it('should click the anchor to trigger download', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('should revoke the Blob URL after download', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('should append and remove the anchor from the DOM', () => {
+    downloadFile('data', 'test.json', 'application/json');
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+  });
+
+  it('should return downloaded: true and iosSafari: false for normal browsers', () => {
+    const result = downloadFile('data', 'test.json', 'application/json');
+    expect(result).toEqual({ downloaded: true, iosSafari: false });
+  });
+
+  it('should detect iOS Safari and open in new tab instead', () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {});
+
+    // Simulate iOS Safari user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+      configurable: true,
+    });
+
+    const result = downloadFile('data', 'test.json', 'application/json');
+
+    expect(openSpy).toHaveBeenCalledWith('blob:mock-url', '_blank');
+    expect(result).toEqual({ downloaded: true, iosSafari: true });
+    // On iOS Safari, click should NOT be called (opens in new tab instead)
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    openSpy.mockRestore();
+  });
+});

--- a/src/services/__tests__/importExport.integration.test.js
+++ b/src/services/__tests__/importExport.integration.test.js
@@ -1,0 +1,836 @@
+/**
+ * Import/Export Integration Tests
+ *
+ * End-to-end round-trip tests, large file handling, Hebrew CSV,
+ * invalid file rejection, replace mode, security, and performance.
+ *
+ * These tests use the REAL services (no mocks for db/export/import)
+ * with fake-indexeddb provided by the test setup.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { exportToJSON, exportToCSV } from '../exportService';
+import {
+  parseJSONFile,
+  parseCSVFile,
+  importEntries,
+  IMPORT_MODE_MERGE,
+  IMPORT_MODE_REPLACE,
+  FILE_SIZE_LIMIT,
+  FILE_SIZE_WARNING,
+  SCHEMA_VERSION,
+} from '../importService';
+import { addEntry, getAllEntries, clearAllEntries } from '../db';
+import { NOTE_MAX_LENGTH } from '../validation';
+
+// --- Helpers ---
+
+/**
+ * Create a mock File from string content.
+ */
+function createMockFile(content, name = 'test.json', size = null) {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const file = new File([blob], name);
+  if (size !== null) {
+    Object.defineProperty(file, 'size', { value: size });
+  }
+  return file;
+}
+
+/**
+ * Create a well-formed entry for direct IndexedDB storage.
+ */
+function makeStorageEntry(overrides = {}) {
+  return {
+    id: crypto.randomUUID(),
+    type: 'income',
+    date: '2026-03-15',
+    amount: 1000,
+    note: 'Test entry',
+    accountingMonth: '2026-03',
+    ...overrides,
+  };
+}
+
+/**
+ * Seed the database with N entries and return them.
+ */
+async function seedEntries(count, overridesFn = () => ({})) {
+  const entries = [];
+  for (let i = 0; i < count; i++) {
+    const entry = makeStorageEntry({
+      amount: 100 + i,
+      note: `Entry ${i + 1}`,
+      ...overridesFn(i),
+    });
+    await addEntry(entry);
+    entries.push(entry);
+  }
+  return entries;
+}
+
+// Clean database between tests
+beforeEach(async () => {
+  await clearAllEntries();
+});
+
+// ========================================================================
+// Round-Trip Tests: JSON
+// ========================================================================
+describe('Round-trip: JSON export -> reimport', () => {
+  it('should export entries to JSON and reimport with identical data', async () => {
+    // Seed 5 entries of different types
+    const original = await seedEntries(5, (i) => ({
+      type: i % 2 === 0 ? 'income' : 'donation',
+      date: `2026-03-${String(i + 1).padStart(2, '0')}`,
+      note: `Note for entry ${i}`,
+    }));
+
+    // Export to JSON
+    const jsonString = exportToJSON(original);
+    expect(jsonString).toBeTruthy();
+
+    // Clear database
+    await clearAllEntries();
+    const afterClear = await getAllEntries();
+    expect(afterClear).toHaveLength(0);
+
+    // Reimport the JSON
+    const file = createMockFile(jsonString, 'roundtrip.json');
+    const parsed = await parseJSONFile(file);
+
+    expect(parsed.validEntries).toHaveLength(5);
+    expect(parsed.errors.filter((e) => !e.startsWith('Entry'))).toHaveLength(0);
+
+    // Import into database
+    const importResult = await importEntries(parsed.validEntries, IMPORT_MODE_MERGE);
+    expect(importResult.success).toBe(true);
+    expect(importResult.imported).toBe(5);
+
+    // Verify data matches
+    const reimported = await getAllEntries();
+    expect(reimported).toHaveLength(5);
+
+    for (let i = 0; i < 5; i++) {
+      const orig = original[i];
+      const re = reimported.find((e) => e.amount === orig.amount);
+      expect(re).toBeDefined();
+      expect(re.type).toBe(orig.type);
+      expect(re.date).toBe(orig.date);
+    }
+  });
+
+  it('should preserve notes through JSON round-trip', async () => {
+    const original = await seedEntries(1, () => ({
+      note: 'Special chars: "quotes", commas, and unicode \u00e9\u00e8',
+    }));
+
+    const jsonString = exportToJSON(original);
+    await clearAllEntries();
+
+    const file = createMockFile(jsonString, 'notes.json');
+    const parsed = await parseJSONFile(file);
+    await importEntries(parsed.validEntries, IMPORT_MODE_MERGE);
+
+    const reimported = await getAllEntries();
+    expect(reimported[0].note).toContain('Special chars');
+    expect(reimported[0].note).toContain('"quotes"');
+  });
+});
+
+// ========================================================================
+// Round-Trip Tests: CSV
+// ========================================================================
+describe('Round-trip: CSV export -> reimport', () => {
+  it('should export entries to CSV and reimport with matching data', async () => {
+    const original = await seedEntries(3, (i) => ({
+      type: i === 0 ? 'income' : 'donation',
+      date: `2026-03-${String(10 + i).padStart(2, '0')}`,
+      amount: 1000 * (i + 1),
+      note: `CSV note ${i}`,
+    }));
+
+    // Export to CSV
+    const csvString = await exportToCSV(original);
+    expect(csvString).toBeTruthy();
+
+    // Clear and reimport
+    await clearAllEntries();
+    const file = createMockFile(csvString, 'roundtrip.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(3);
+
+    const importResult = await importEntries(parsed.validEntries, IMPORT_MODE_MERGE);
+    expect(importResult.success).toBe(true);
+    expect(importResult.imported).toBe(3);
+
+    // Verify data
+    const reimported = await getAllEntries();
+    expect(reimported).toHaveLength(3);
+
+    for (const orig of original) {
+      const match = reimported.find((e) => e.amount === orig.amount);
+      expect(match).toBeDefined();
+      expect(match.type).toBe(orig.type);
+      expect(match.date).toBe(orig.date);
+    }
+  });
+
+  it('should handle notes with commas in CSV round-trip', async () => {
+    const original = await seedEntries(1, () => ({
+      note: 'Payment for rent, utilities, and food',
+    }));
+
+    const csvString = await exportToCSV(original);
+    await clearAllEntries();
+
+    const file = createMockFile(csvString, 'commas.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(1);
+    expect(parsed.validEntries[0].note).toContain('Payment for rent');
+  });
+});
+
+// ========================================================================
+// Large File Tests
+// ========================================================================
+describe('Large file handling', () => {
+  it('should export and reimport 1000 entries via JSON with all present', async () => {
+    const entries = [];
+    for (let i = 0; i < 1000; i++) {
+      entries.push(makeStorageEntry({
+        amount: i + 1,
+        note: `Bulk entry ${i}`,
+        date: `2026-01-${String((i % 28) + 1).padStart(2, '0')}`,
+      }));
+    }
+
+    // Add all entries to database
+    for (const entry of entries) {
+      await addEntry(entry);
+    }
+
+    const allEntries = await getAllEntries();
+    expect(allEntries).toHaveLength(1000);
+
+    // Export
+    const jsonString = exportToJSON(allEntries);
+
+    // Clear and reimport
+    await clearAllEntries();
+    const file = createMockFile(jsonString, 'bulk.json');
+    const parsed = await parseJSONFile(file);
+    expect(parsed.validEntries).toHaveLength(1000);
+
+    const importResult = await importEntries(parsed.validEntries, IMPORT_MODE_MERGE);
+    expect(importResult.success).toBe(true);
+    expect(importResult.imported).toBe(1000);
+
+    const reimported = await getAllEntries();
+    expect(reimported).toHaveLength(1000);
+  }, 30000);
+
+  it('should export and reimport 1000 entries via CSV with all present', async () => {
+    const entries = [];
+    for (let i = 0; i < 1000; i++) {
+      entries.push(makeStorageEntry({
+        amount: i + 1,
+        note: `CSV bulk ${i}`,
+        date: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
+      }));
+    }
+
+    for (const entry of entries) {
+      await addEntry(entry);
+    }
+
+    const allEntries = await getAllEntries();
+    const csvString = await exportToCSV(allEntries);
+
+    await clearAllEntries();
+    const file = createMockFile(csvString, 'bulk.csv');
+    const parsed = await parseCSVFile(file);
+    expect(parsed.validEntries).toHaveLength(1000);
+
+    const importResult = await importEntries(parsed.validEntries, IMPORT_MODE_MERGE);
+    expect(importResult.success).toBe(true);
+    expect(importResult.imported).toBe(1000);
+
+    const reimported = await getAllEntries();
+    expect(reimported).toHaveLength(1000);
+  }, 30000);
+});
+
+// ========================================================================
+// Hebrew CSV Tests
+// ========================================================================
+describe('Hebrew CSV import/export', () => {
+  it('should export Hebrew data in CSV and reimport correctly', async () => {
+    const original = await seedEntries(2, (i) => ({
+      type: i === 0 ? 'income' : 'donation',
+      note: i === 0 ? '\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA \u05D7\u05D5\u05D3\u05E9\u05D9\u05EA' : '\u05EA\u05E8\u05D5\u05DE\u05D4 \u05DC\u05E2\u05E0\u05D9\u05D9\u05DD',
+    }));
+
+    const csvString = await exportToCSV(original);
+
+    // Verify Hebrew text is present in export
+    expect(csvString).toContain('\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA');
+    expect(csvString).toContain('\u05EA\u05E8\u05D5\u05DE\u05D4');
+
+    await clearAllEntries();
+    const file = createMockFile(csvString, 'hebrew.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(2);
+    // Verify Hebrew notes survived round-trip
+    const notes = parsed.validEntries.map((e) => e.note);
+    expect(notes.some((n) => n.includes('\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA'))).toBe(true);
+    expect(notes.some((n) => n.includes('\u05EA\u05E8\u05D5\u05DE\u05D4'))).toBe(true);
+  });
+
+  it('should import CSV with Hebrew column headers', async () => {
+    const csv = '\u05E1\u05D5\u05D2,\u05E1\u05DB\u05D5\u05DD,\u05EA\u05D0\u05E8\u05D9\u05DA,\u05D4\u05E2\u05E8\u05D4\n\u05D4\u05DB\u05E0\u05E1\u05D4,5000,15/03/2026,\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA\n\u05EA\u05E8\u05D5\u05DE\u05D4,500,16/03/2026,\u05E6\u05D3\u05E7\u05D4';
+    const file = createMockFile(csv, 'hebrew-headers.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(2);
+    expect(parsed.validEntries[0].type).toBe('income');
+    expect(parsed.validEntries[0].amount).toBe(5000);
+    expect(parsed.validEntries[0].date).toBe('2026-03-15');
+    expect(parsed.validEntries[1].type).toBe('donation');
+    expect(parsed.validEntries[1].amount).toBe(500);
+  });
+
+  it('should import CSV with BOM and CRLF line endings (Windows Excel)', async () => {
+    const csv = '\uFEFFtype,amount,date,note\r\nincome,2000,2026-03-15,\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA\r\ndonation,200,2026-03-16,\u05EA\u05E8\u05D5\u05DE\u05D4\r\n';
+    const file = createMockFile(csv, 'excel-export.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(2);
+    expect(parsed.validEntries[0].type).toBe('income');
+    expect(parsed.validEntries[0].amount).toBe(2000);
+    expect(parsed.validEntries[1].type).toBe('donation');
+  });
+
+  it('should import CSV with semicolon delimiters (European Excel)', async () => {
+    const csv = 'type;amount;date;note\nincome;3000;2026-03-15;\u05DE\u05E9\u05DB\u05D5\u05E8\u05EA\ndonation;300;2026-03-16;\u05E6\u05D3\u05E7\u05D4';
+    const file = createMockFile(csv, 'european.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(2);
+    expect(parsed.validEntries[0].amount).toBe(3000);
+    expect(parsed.validEntries[1].amount).toBe(300);
+  });
+
+  it('should preserve Hebrew text with mixed LTR numbers', async () => {
+    const csv = 'type,amount,date,note\nincome,1500,2026-03-15,"\u05EA\u05E9\u05DC\u05D5\u05DD 1500 \u05E9\u05E7\u05DC"';
+    const file = createMockFile(csv, 'mixed-dir.csv');
+    const parsed = await parseCSVFile(file);
+
+    expect(parsed.validEntries).toHaveLength(1);
+    expect(parsed.validEntries[0].note).toContain('1500');
+    expect(parsed.validEntries[0].note).toContain('\u05EA\u05E9\u05DC\u05D5\u05DD');
+  });
+});
+
+// ========================================================================
+// Invalid File Rejection
+// ========================================================================
+describe('Invalid file rejection', () => {
+  it('should reject malformed JSON with clear error', async () => {
+    const file = createMockFile('{ broken json: }}}', 'bad.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Invalid JSON format');
+  });
+
+  it('should reject JSON with wrong schema version', async () => {
+    const json = JSON.stringify({ version: 999, entries: [{ type: 'income', amount: 100, date: '2026-03-15' }] });
+    const file = createMockFile(json, 'wrong-version.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('Unsupported schema version');
+    expect(result.errors[0]).toContain('999');
+  });
+
+  it('should reject CSV with missing required columns', async () => {
+    const csv = 'name,value,description\nTest,100,Some note';
+    const file = createMockFile(csv, 'missing-cols.csv');
+    const result = await parseCSVFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('Missing required columns');
+    expect(result.errors[0]).toContain('type');
+    expect(result.errors[0]).toContain('amount');
+    expect(result.errors[0]).toContain('date');
+  });
+
+  it('should reject empty JSON file', async () => {
+    const file = createMockFile('', 'empty.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject empty CSV file', async () => {
+    const file = createMockFile('', 'empty.csv');
+    const result = await parseCSVFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject file exceeding 10 MB (JSON)', async () => {
+    const file = createMockFile('{}', 'huge.json', FILE_SIZE_LIMIT + 1);
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('exceeds maximum limit');
+  });
+
+  it('should reject file exceeding 10 MB (CSV)', async () => {
+    const file = createMockFile('type,amount,date', 'huge.csv', FILE_SIZE_LIMIT + 1);
+    const result = await parseCSVFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('exceeds maximum limit');
+  });
+
+  it('should warn for file between 5-10 MB (JSON)', async () => {
+    // Create valid JSON content but override size to trigger warning
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [{ type: 'income', amount: 100, date: '2026-03-15' }],
+    });
+    const file = createMockFile(json, 'medium.json', FILE_SIZE_WARNING + 1);
+    const result = await parseJSONFile(file);
+
+    expect(result.warnings.some((w) => w.includes('large'))).toBe(true);
+  });
+
+  it('should reject binary content with .json extension', async () => {
+    // Simulate binary content (null bytes and random data)
+    const binaryContent = '\x00\x01\x02\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR';
+    const file = createMockFile(binaryContent, 'image.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject JSON that is an array (missing envelope)', async () => {
+    const json = JSON.stringify([{ type: 'income', amount: 100, date: '2026-03-15' }]);
+    const file = createMockFile(json, 'array.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('JSON must be an object');
+  });
+
+  it('should reject JSON envelope with missing entries array', async () => {
+    const json = JSON.stringify({ version: SCHEMA_VERSION });
+    const file = createMockFile(json, 'no-entries.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('entries');
+  });
+
+  it('should reject JSON envelope with empty entries array', async () => {
+    const json = JSON.stringify({ version: SCHEMA_VERSION, entries: [] });
+    const file = createMockFile(json, 'empty-entries.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('No entries found');
+  });
+
+  it('should separate valid and invalid entries in JSON', async () => {
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [
+        { type: 'income', amount: 1000, date: '2026-03-15' },
+        { type: 'invalid-type', amount: -1, date: '' },
+        { type: 'donation', amount: 500, date: '2026-03-16' },
+      ],
+    });
+    const file = createMockFile(json, 'mixed.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(2);
+    expect(result.invalidEntries).toHaveLength(1);
+  });
+});
+
+// ========================================================================
+// Replace Mode Tests
+// ========================================================================
+describe('Replace mode (IMPORT_MODE_REPLACE)', () => {
+  it('should clear old data and add new data', async () => {
+    // Seed 3 old entries
+    await seedEntries(3, (i) => ({
+      note: `Old entry ${i}`,
+      amount: 100 + i,
+    }));
+    const before = await getAllEntries();
+    expect(before).toHaveLength(3);
+
+    // New entries to import
+    const newEntries = [
+      { type: 'income', amount: 9999, date: '2026-06-01', note: 'New data 1' },
+      { type: 'donation', amount: 8888, date: '2026-06-02', note: 'New data 2' },
+    ];
+
+    const result = await importEntries(newEntries, IMPORT_MODE_REPLACE, { skipBackup: true });
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(2);
+
+    // Verify old data is gone, new data is present
+    const after = await getAllEntries();
+    expect(after).toHaveLength(2);
+    expect(after.every((e) => e.note.startsWith('New data'))).toBe(true);
+    expect(after.some((e) => e.amount === 9999)).toBe(true);
+    expect(after.some((e) => e.amount === 8888)).toBe(true);
+  });
+
+  it('should not contain any old entries after replace', async () => {
+    const oldEntries = await seedEntries(5, (i) => ({
+      note: `DELETE_ME_${i}`,
+      amount: 1 + i,
+    }));
+
+    const newEntries = [
+      { type: 'income', amount: 50000, date: '2026-07-01', note: 'Fresh start' },
+    ];
+
+    await importEntries(newEntries, IMPORT_MODE_REPLACE, { skipBackup: true });
+
+    const after = await getAllEntries();
+    // None of the old IDs should exist
+    for (const old of oldEntries) {
+      expect(after.find((e) => e.id === old.id)).toBeUndefined();
+    }
+    expect(after).toHaveLength(1);
+    expect(after[0].note).toBe('Fresh start');
+  });
+});
+
+// ========================================================================
+// Security Tests
+// ========================================================================
+describe('Security: sanitization and injection prevention', () => {
+  it('should strip __proto__ key from JSON import (prototype pollution)', async () => {
+    // Manually construct JSON with __proto__
+    const maliciousJson = `{
+      "version": ${SCHEMA_VERSION},
+      "entries": [
+        {
+          "type": "income",
+          "amount": 1000,
+          "date": "2026-03-15",
+          "note": "normal",
+          "__proto__": { "isAdmin": true }
+        }
+      ]
+    }`;
+    const file = createMockFile(maliciousJson, 'proto.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+    // The prototype pollution key should be stripped
+    const entry = result.validEntries[0];
+    expect(entry).not.toHaveProperty('__proto__', { isAdmin: true });
+    expect(entry).not.toHaveProperty('isAdmin');
+  });
+
+  it('should strip constructor key from JSON import', async () => {
+    const maliciousJson = `{
+      "version": ${SCHEMA_VERSION},
+      "entries": [
+        {
+          "type": "income",
+          "amount": 500,
+          "date": "2026-03-15",
+          "constructor": { "polluted": true }
+        }
+      ]
+    }`;
+    const file = createMockFile(maliciousJson, 'constructor.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+    expect(result.validEntries[0]).not.toHaveProperty('constructor', { polluted: true });
+  });
+
+  it('should prevent formula injection in CSV export (=CMD)', async () => {
+    const entries = [makeStorageEntry({ note: '=CMD("calc")' })];
+    const csvString = await exportToCSV(entries);
+
+    // The = should be prefixed with a single quote
+    expect(csvString).toContain("'=CMD");
+    expect(csvString).not.toMatch(/[^']=CMD/);
+  });
+
+  it('should prevent formula injection in CSV export (+cmd|)', async () => {
+    const entries = [makeStorageEntry({ note: '+cmd|/C calc' })];
+    const csvString = await exportToCSV(entries);
+
+    expect(csvString).toContain("'+cmd|");
+  });
+
+  it('should prevent formula injection in CSV export (@SUM)', async () => {
+    const entries = [makeStorageEntry({ note: '@SUM(A1:A10)' })];
+    const csvString = await exportToCSV(entries);
+
+    expect(csvString).toContain("'@SUM");
+  });
+
+  it('should sanitize XSS payloads in note field during import', async () => {
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [
+        {
+          type: 'income',
+          amount: 1000,
+          date: '2026-03-15',
+          note: '<script>alert("xss")</script>',
+        },
+      ],
+    });
+    const file = createMockFile(json, 'xss.json');
+    const result = await parseJSONFile(file);
+
+    // The entry should still be valid (React auto-escapes on render)
+    // but the import service should accept it without executing
+    expect(result.validEntries).toHaveLength(1);
+    // Note is preserved as text (not executed) - React escapes on render
+    expect(result.validEntries[0].note).toContain('script');
+  });
+
+  it('should handle very long strings (>10KB in a single field) gracefully', async () => {
+    const longNote = 'A'.repeat(15000);
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [
+        {
+          type: 'income',
+          amount: 1000,
+          date: '2026-03-15',
+          note: longNote,
+        },
+      ],
+    });
+    const file = createMockFile(json, 'long-note.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+    // Note should be truncated to NOTE_MAX_LENGTH
+    expect(result.validEntries[0].note.length).toBeLessThanOrEqual(NOTE_MAX_LENGTH);
+  });
+
+  it('should strip control characters from notes during import', async () => {
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [
+        {
+          type: 'income',
+          amount: 1000,
+          date: '2026-03-15',
+          note: 'Normal\x00Hidden\x01Data\x07Bell',
+        },
+      ],
+    });
+    const file = createMockFile(json, 'control-chars.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+    const note = result.validEntries[0].note;
+    // Control characters should be stripped
+    expect(note).not.toContain('\x00');
+    expect(note).not.toContain('\x01');
+    expect(note).not.toContain('\x07');
+    expect(note).toContain('Normal');
+    expect(note).toContain('Hidden');
+  });
+});
+
+// ========================================================================
+// Performance Benchmarks
+// ========================================================================
+describe('Performance benchmarks', () => {
+  it('should import 1000 entries in under 10 seconds (fake-indexeddb overhead)', async () => {
+    // Generate 1000 validated entries
+    // Note: fake-indexeddb in test env is ~2x slower than real IndexedDB,
+    // so we use 10s threshold here. Real browser would be < 5s.
+    const entries = Array.from({ length: 1000 }, (_, i) => ({
+      type: i % 2 === 0 ? 'income' : 'donation',
+      amount: 100 + i,
+      date: `2026-01-${String((i % 28) + 1).padStart(2, '0')}`,
+      note: `Perf test ${i}`,
+    }));
+
+    const start = performance.now();
+    const result = await importEntries(entries, IMPORT_MODE_MERGE);
+    const elapsed = performance.now() - start;
+
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1000);
+    expect(elapsed).toBeLessThan(10000);
+  }, 15000);
+
+  it('should export 1000 entries to JSON in under 2 seconds', async () => {
+    // Seed 1000 entries
+    const entries = [];
+    for (let i = 0; i < 1000; i++) {
+      entries.push(makeStorageEntry({
+        amount: i + 1,
+        note: `Export perf ${i}`,
+        date: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
+      }));
+    }
+
+    const start = performance.now();
+    const jsonString = exportToJSON(entries);
+    const elapsed = performance.now() - start;
+
+    expect(typeof jsonString).toBe('string');
+    expect(jsonString.length).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(2000);
+  }, 5000);
+
+  it('should export 1000 entries to CSV in under 3 seconds', async () => {
+    const entries = [];
+    for (let i = 0; i < 1000; i++) {
+      entries.push(makeStorageEntry({
+        amount: i + 1,
+        note: `CSV perf ${i}`,
+        date: `2026-03-${String((i % 28) + 1).padStart(2, '0')}`,
+      }));
+    }
+
+    const start = performance.now();
+    const csvString = await exportToCSV(entries);
+    const elapsed = performance.now() - start;
+
+    expect(typeof csvString).toBe('string');
+    expect(csvString.length).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(3000);
+  }, 5000);
+
+  it('should fire progress callbacks during large import', async () => {
+    const entries = Array.from({ length: 250 }, (_, i) => ({
+      type: 'income',
+      amount: 100 + i,
+      date: '2026-03-15',
+      note: `Progress ${i}`,
+    }));
+
+    const progressCalls = [];
+    const onProgress = (p) => progressCalls.push({ ...p });
+
+    await importEntries(entries, IMPORT_MODE_MERGE, { onProgress });
+
+    expect(progressCalls.length).toBeGreaterThan(0);
+    // Should have validating, importing, and complete phases
+    const phases = new Set(progressCalls.map((p) => p.phase));
+    expect(phases.has('validating')).toBe(true);
+    expect(phases.has('complete')).toBe(true);
+  }, 10000);
+});
+
+// ========================================================================
+// Merge Mode Additional Tests
+// ========================================================================
+describe('Merge mode preserves existing entries', () => {
+  it('should add new entries alongside existing ones', async () => {
+    // Seed 3 existing entries
+    await seedEntries(3, (i) => ({
+      note: `Existing ${i}`,
+      amount: 100 + i,
+    }));
+
+    // Import 2 new entries via merge
+    const newEntries = [
+      { type: 'income', amount: 9000, date: '2026-05-01', note: 'New 1' },
+      { type: 'donation', amount: 8000, date: '2026-05-02', note: 'New 2' },
+    ];
+
+    const result = await importEntries(newEntries, IMPORT_MODE_MERGE);
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(2);
+
+    // Should now have 5 total entries
+    const all = await getAllEntries();
+    expect(all).toHaveLength(5);
+  });
+});
+
+// ========================================================================
+// Edge Cases
+// ========================================================================
+describe('Edge cases', () => {
+  it('should handle import of a single entry', async () => {
+    const entries = [{ type: 'income', amount: 42, date: '2026-03-15', note: 'Single' }];
+    const result = await importEntries(entries, IMPORT_MODE_MERGE);
+
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+
+    const all = await getAllEntries();
+    expect(all).toHaveLength(1);
+    expect(all[0].amount).toBe(42);
+  });
+
+  it('should reject import with empty entries array', async () => {
+    const result = await importEntries([], IMPORT_MODE_MERGE);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('No entries');
+  });
+
+  it('should reject import with null entries', async () => {
+    const result = await importEntries(null, IMPORT_MODE_MERGE);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('No entries');
+  });
+
+  it('should reject invalid import mode', async () => {
+    const entries = [{ type: 'income', amount: 100, date: '2026-03-15' }];
+    const result = await importEntries(entries, 'invalid-mode');
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Invalid import mode');
+  });
+
+  it('should handle entries with undefined note field', async () => {
+    const json = JSON.stringify({
+      version: SCHEMA_VERSION,
+      entries: [
+        { type: 'income', amount: 1000, date: '2026-03-15' },
+      ],
+    });
+    const file = createMockFile(json, 'no-note.json');
+    const result = await parseJSONFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+
+    const importResult = await importEntries(result.validEntries, IMPORT_MODE_MERGE);
+    expect(importResult.success).toBe(true);
+
+    const all = await getAllEntries();
+    expect(all).toHaveLength(1);
+  });
+
+  it('should handle special characters in CSV notes (quotes, newlines)', async () => {
+    const csv = 'type,amount,date,note\nincome,1000,2026-03-15,"Note with ""double quotes"" inside"';
+    const file = createMockFile(csv, 'special.csv');
+    const result = await parseCSVFile(file);
+
+    expect(result.validEntries).toHaveLength(1);
+    expect(result.validEntries[0].note).toContain('double quotes');
+  });
+});

--- a/src/services/__tests__/importService.test.js
+++ b/src/services/__tests__/importService.test.js
@@ -1,0 +1,1248 @@
+/**
+ * Tests for Import Service
+ *
+ * Covers JSON/CSV parsing, date detection, header mapping,
+ * amount coercion, type mapping, security sanitization, and file size validation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validateFileSize,
+  FILE_SIZE_WARNING,
+  FILE_SIZE_LIMIT,
+  stripBOM,
+  sanitizeObject,
+  parseDateValue,
+  mapCSVHeaders,
+  HEBREW_HEADER_MAP,
+  HEBREW_TYPE_MAP,
+  parseAmount,
+  mapTypeValue,
+  sanitizeNote,
+  validateImportEntry,
+  parseJSONFile,
+  parseCSVFile,
+  SCHEMA_VERSION,
+  // Import Engine exports
+  IMPORT_MODE_MERGE,
+  IMPORT_MODE_REPLACE,
+  INDEXEDDB_BATCH_SIZE,
+  prepareEntryForStorage,
+  createAutoBackup,
+  batchWriteIndexedDB,
+  mergeEntries,
+  replaceAllEntries,
+  importEntries,
+} from '../importService';
+import { NOTE_MAX_LENGTH } from '../validation';
+
+// --- Helper: create a mock File ---
+function createMockFile(content, name = 'test.json', size = null) {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const file = new File([blob], name);
+  if (size !== null) {
+    Object.defineProperty(file, 'size', { value: size });
+  }
+  return file;
+}
+
+// ========================================================================
+// validateFileSize
+// ========================================================================
+describe('validateFileSize', () => {
+  it('should accept a small file', () => {
+    const file = createMockFile('small', 'test.json', 1000);
+    const result = validateFileSize(file);
+    expect(result.valid).toBe(true);
+    expect(result.warning).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it('should warn for files above 5MB', () => {
+    const file = createMockFile('', 'big.json', FILE_SIZE_WARNING + 1);
+    const result = validateFileSize(file);
+    expect(result.valid).toBe(true);
+    expect(result.warning).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it('should reject files above 10MB', () => {
+    const file = createMockFile('', 'huge.json', FILE_SIZE_LIMIT + 1);
+    const result = validateFileSize(file);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('exceeds maximum limit');
+  });
+
+  it('should accept file exactly at 5MB', () => {
+    const file = createMockFile('', 'edge.json', FILE_SIZE_WARNING);
+    const result = validateFileSize(file);
+    expect(result.valid).toBe(true);
+    expect(result.warning).toBe(false);
+  });
+
+  it('should accept file exactly at 10MB', () => {
+    const file = createMockFile('', 'edge.json', FILE_SIZE_LIMIT);
+    const result = validateFileSize(file);
+    expect(result.valid).toBe(true);
+    expect(result.warning).toBe(true);
+  });
+
+  it('should reject null file', () => {
+    const result = validateFileSize(null);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid file object');
+  });
+
+  it('should reject file without size property', () => {
+    const result = validateFileSize({});
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Invalid file object');
+  });
+});
+
+// ========================================================================
+// stripBOM
+// ========================================================================
+describe('stripBOM', () => {
+  it('should strip UTF-8 BOM from text', () => {
+    const text = '\uFEFFhello world';
+    expect(stripBOM(text)).toBe('hello world');
+  });
+
+  it('should return text unchanged if no BOM', () => {
+    const text = 'hello world';
+    expect(stripBOM(text)).toBe('hello world');
+  });
+
+  it('should return non-string values as-is', () => {
+    expect(stripBOM(null)).toBe(null);
+    expect(stripBOM(undefined)).toBe(undefined);
+    expect(stripBOM(123)).toBe(123);
+  });
+
+  it('should handle empty string', () => {
+    expect(stripBOM('')).toBe('');
+  });
+
+  it('should handle BOM-only string', () => {
+    expect(stripBOM('\uFEFF')).toBe('');
+  });
+});
+
+// ========================================================================
+// sanitizeObject (prototype pollution protection)
+// ========================================================================
+describe('sanitizeObject', () => {
+  it('should strip __proto__ key', () => {
+    const obj = { name: 'test', '__proto__': { polluted: true } };
+    const result = sanitizeObject(obj);
+    expect(result.name).toBe('test');
+    expect(result).not.toHaveProperty('__proto__', { polluted: true });
+  });
+
+  it('should strip constructor key', () => {
+    const obj = { name: 'test', constructor: { polluted: true } };
+    const result = sanitizeObject(obj);
+    expect(result.name).toBe('test');
+    expect(result).not.toHaveProperty('constructor');
+  });
+
+  it('should strip prototype key', () => {
+    const obj = { name: 'test', prototype: { polluted: true } };
+    const result = sanitizeObject(obj);
+    expect(result.name).toBe('test');
+    expect(result).not.toHaveProperty('prototype');
+  });
+
+  it('should recursively sanitize nested objects', () => {
+    const obj = { a: { '__proto__': 'bad', b: 'good' } };
+    const result = sanitizeObject(obj);
+    expect(result.a.b).toBe('good');
+    expect(Object.keys(result.a)).toEqual(['b']);
+  });
+
+  it('should sanitize arrays', () => {
+    const arr = [{ '__proto__': 'bad', a: 1 }, { b: 2 }];
+    const result = sanitizeObject(arr);
+    expect(result).toHaveLength(2);
+    expect(Object.keys(result[0])).toEqual(['a']);
+    expect(result[1].b).toBe(2);
+  });
+
+  it('should return primitives unchanged', () => {
+    expect(sanitizeObject(null)).toBe(null);
+    expect(sanitizeObject('string')).toBe('string');
+    expect(sanitizeObject(42)).toBe(42);
+    expect(sanitizeObject(true)).toBe(true);
+  });
+
+  it('should handle empty object', () => {
+    expect(sanitizeObject({})).toEqual({});
+  });
+});
+
+// ========================================================================
+// parseDateValue
+// ========================================================================
+describe('parseDateValue', () => {
+  describe('ISO 8601 format', () => {
+    it('should parse YYYY-MM-DD', () => {
+      const result = parseDateValue('2026-03-15');
+      expect(result.date).toBe('2026-03-15');
+      expect(result.format).toBe('ISO');
+      expect(result.error).toBeNull();
+    });
+
+    it('should parse full ISO datetime string', () => {
+      const result = parseDateValue('2026-03-15T10:30:00.000Z');
+      expect(result.date).toBe('2026-03-15');
+      expect(result.format).toBe('ISO');
+    });
+
+    it('should reject invalid ISO date (Feb 30)', () => {
+      const result = parseDateValue('2026-02-30');
+      expect(result.date).toBeNull();
+      expect(result.error).toContain('Unable to parse date');
+    });
+  });
+
+  describe('DD/MM/YYYY format (Israeli default)', () => {
+    it('should parse DD/MM/YYYY', () => {
+      const result = parseDateValue('15/03/2026');
+      expect(result.date).toBe('2026-03-15');
+      expect(result.format).toBe('DD/MM/YYYY');
+    });
+
+    it('should parse D/M/YYYY (single digits)', () => {
+      const result = parseDateValue('5/3/2026');
+      expect(result.date).toBe('2026-03-05');
+      expect(result.format).toBe('DD/MM/YYYY');
+    });
+
+    it('should parse DD.MM.YYYY (dot separator)', () => {
+      const result = parseDateValue('15.03.2026');
+      expect(result.date).toBe('2026-03-15');
+      expect(result.format).toBe('DD/MM/YYYY');
+    });
+
+    it('should parse DD-MM-YYYY (dash separator)', () => {
+      const result = parseDateValue('15-03-2026');
+      expect(result.date).toBe('2026-03-15');
+      expect(result.format).toBe('DD/MM/YYYY');
+    });
+  });
+
+  describe('MM/DD/YYYY fallback', () => {
+    it('should fall back to MM/DD/YYYY when DD/MM/YYYY is invalid', () => {
+      // 13 cannot be a month in DD/MM, but can be a day in MM/DD
+      // 01/13/2026 -> month=13 invalid for DD/MM, so try MM=01, DD=13
+      const result = parseDateValue('01/13/2026');
+      expect(result.date).toBe('2026-01-13');
+      expect(result.format).toBe('MM/DD/YYYY');
+    });
+  });
+
+  describe('ambiguous dates default to DD/MM/YYYY', () => {
+    it('should prefer DD/MM/YYYY for ambiguous dates like 05/06/2026', () => {
+      const result = parseDateValue('05/06/2026');
+      // DD=05, MM=06 -> June 5th (Israeli default)
+      expect(result.date).toBe('2026-06-05');
+      expect(result.format).toBe('DD/MM/YYYY');
+    });
+  });
+
+  describe('error cases', () => {
+    it('should return error for null', () => {
+      const result = parseDateValue(null);
+      expect(result.date).toBeNull();
+      expect(result.error).toBe('Date value is required');
+    });
+
+    it('should return error for empty string', () => {
+      const result = parseDateValue('');
+      expect(result.date).toBeNull();
+      expect(result.error).toBe('Date value is required');
+    });
+
+    it('should return error for non-string', () => {
+      const result = parseDateValue(12345);
+      expect(result.date).toBeNull();
+      expect(result.error).toBe('Date value is required');
+    });
+
+    it('should return error for garbage text', () => {
+      const result = parseDateValue('not-a-date');
+      expect(result.date).toBeNull();
+      expect(result.error).toContain('Unable to parse date');
+    });
+
+    it('should return error for invalid date parts (month 13 in ISO)', () => {
+      const result = parseDateValue('2026-13-01');
+      expect(result.date).toBeNull();
+    });
+  });
+});
+
+// ========================================================================
+// mapCSVHeaders
+// ========================================================================
+describe('mapCSVHeaders', () => {
+  it('should map Hebrew headers to internal names', () => {
+    const headers = ['סוג', 'סכום', 'תאריך', 'הערה'];
+    const { mapped, unmapped } = mapCSVHeaders(headers);
+    expect(mapped['סוג']).toBe('type');
+    expect(mapped['סכום']).toBe('amount');
+    expect(mapped['תאריך']).toBe('date');
+    expect(mapped['הערה']).toBe('note');
+    expect(unmapped).toHaveLength(0);
+  });
+
+  it('should map English headers case-insensitively', () => {
+    const headers = ['Type', 'Amount', 'Date', 'Note'];
+    const { mapped } = mapCSVHeaders(headers);
+    expect(mapped['Type']).toBe('type');
+    expect(mapped['Amount']).toBe('amount');
+    expect(mapped['Date']).toBe('date');
+    expect(mapped['Note']).toBe('note');
+  });
+
+  it('should track unmapped headers', () => {
+    const headers = ['type', 'amount', 'date', 'unknown_column'];
+    const { unmapped } = mapCSVHeaders(headers);
+    expect(unmapped).toContain('unknown_column');
+  });
+
+  it('should handle mixed Hebrew and English headers', () => {
+    const headers = ['סוג', 'amount', 'תאריך', 'note'];
+    const { mapped, unmapped } = mapCSVHeaders(headers);
+    expect(mapped['סוג']).toBe('type');
+    expect(mapped['amount']).toBe('amount');
+    expect(mapped['תאריך']).toBe('date');
+    expect(mapped['note']).toBe('note');
+    expect(unmapped).toHaveLength(0);
+  });
+
+  it('should handle empty headers array', () => {
+    const { mapped, unmapped } = mapCSVHeaders([]);
+    expect(Object.keys(mapped)).toHaveLength(0);
+    expect(unmapped).toHaveLength(0);
+  });
+
+  it('should handle non-array input gracefully', () => {
+    const { mapped, unmapped } = mapCSVHeaders(null);
+    expect(Object.keys(mapped)).toHaveLength(0);
+    expect(unmapped).toHaveLength(0);
+  });
+
+  it('should map "notes" (plural) to note', () => {
+    const headers = ['notes'];
+    const { mapped } = mapCSVHeaders(headers);
+    expect(mapped['notes']).toBe('note');
+  });
+
+  it('should map Hebrew "הערות" (plural) to note', () => {
+    const headers = ['הערות'];
+    const { mapped } = mapCSVHeaders(headers);
+    expect(mapped['הערות']).toBe('note');
+  });
+
+  it('should map "מעשר" to maaser', () => {
+    const headers = ['מעשר'];
+    const { mapped } = mapCSVHeaders(headers);
+    expect(mapped['מעשר']).toBe('maaser');
+  });
+});
+
+// ========================================================================
+// parseAmount
+// ========================================================================
+describe('parseAmount', () => {
+  it('should accept a valid number', () => {
+    const result = parseAmount(1000);
+    expect(result.amount).toBe(1000);
+    expect(result.error).toBeNull();
+  });
+
+  it('should accept a decimal number', () => {
+    const result = parseAmount(1000.50);
+    expect(result.amount).toBe(1000.50);
+  });
+
+  it('should parse a numeric string', () => {
+    const result = parseAmount('1000');
+    expect(result.amount).toBe(1000);
+  });
+
+  it('should parse a comma-separated string', () => {
+    const result = parseAmount('1,000.50');
+    expect(result.amount).toBe(1000.50);
+  });
+
+  it('should parse a string with multiple commas', () => {
+    const result = parseAmount('1,000,000');
+    expect(result.amount).toBe(1000000);
+  });
+
+  it('should reject null', () => {
+    const result = parseAmount(null);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount is required');
+  });
+
+  it('should reject empty string', () => {
+    const result = parseAmount('');
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount is required');
+  });
+
+  it('should reject NaN', () => {
+    const result = parseAmount(NaN);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be a finite number');
+  });
+
+  it('should reject Infinity', () => {
+    const result = parseAmount(Infinity);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be a finite number');
+  });
+
+  it('should reject negative amount', () => {
+    const result = parseAmount(-100);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be positive');
+  });
+
+  it('should reject zero', () => {
+    const result = parseAmount(0);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be positive');
+  });
+
+  it('should reject non-numeric string', () => {
+    const result = parseAmount('abc');
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be a finite number');
+  });
+
+  it('should reject boolean', () => {
+    const result = parseAmount(true);
+    expect(result.amount).toBeNull();
+    expect(result.error).toBe('Amount must be a number or numeric string');
+  });
+});
+
+// ========================================================================
+// mapTypeValue
+// ========================================================================
+describe('mapTypeValue', () => {
+  it('should map "income" directly', () => {
+    expect(mapTypeValue('income').type).toBe('income');
+  });
+
+  it('should map "donation" directly', () => {
+    expect(mapTypeValue('donation').type).toBe('donation');
+  });
+
+  it('should map "maaser" directly', () => {
+    expect(mapTypeValue('maaser').type).toBe('maaser');
+  });
+
+  it('should be case-insensitive for English', () => {
+    expect(mapTypeValue('Income').type).toBe('income');
+    expect(mapTypeValue('DONATION').type).toBe('donation');
+  });
+
+  it('should map Hebrew "הכנסה" to income', () => {
+    expect(mapTypeValue('הכנסה').type).toBe('income');
+  });
+
+  it('should map Hebrew "תרומה" to donation', () => {
+    expect(mapTypeValue('תרומה').type).toBe('donation');
+  });
+
+  it('should map Hebrew "מעשר" to maaser', () => {
+    expect(mapTypeValue('מעשר').type).toBe('maaser');
+  });
+
+  it('should reject invalid type', () => {
+    const result = mapTypeValue('expense');
+    expect(result.type).toBeNull();
+    expect(result.error).toContain('Invalid type');
+  });
+
+  it('should reject null', () => {
+    const result = mapTypeValue(null);
+    expect(result.type).toBeNull();
+    expect(result.error).toBe('Type is required');
+  });
+
+  it('should reject empty string', () => {
+    const result = mapTypeValue('');
+    expect(result.type).toBeNull();
+    expect(result.error).toBe('Type is required');
+  });
+
+  it('should trim whitespace', () => {
+    expect(mapTypeValue('  income  ').type).toBe('income');
+  });
+});
+
+// ========================================================================
+// sanitizeNote
+// ========================================================================
+describe('sanitizeNote', () => {
+  it('should return empty string for null', () => {
+    expect(sanitizeNote(null)).toBe('');
+  });
+
+  it('should return empty string for undefined', () => {
+    expect(sanitizeNote(undefined)).toBe('');
+  });
+
+  it('should convert non-string to string', () => {
+    expect(sanitizeNote(123)).toBe('123');
+  });
+
+  it('should trim whitespace', () => {
+    expect(sanitizeNote('  hello  ')).toBe('hello');
+  });
+
+  it('should strip control characters', () => {
+    expect(sanitizeNote('hello\x00world')).toBe('helloworld');
+  });
+
+  it('should truncate to NOTE_MAX_LENGTH', () => {
+    const longNote = 'a'.repeat(NOTE_MAX_LENGTH + 100);
+    const result = sanitizeNote(longNote);
+    expect(result.length).toBe(NOTE_MAX_LENGTH);
+  });
+
+  it('should preserve valid text', () => {
+    expect(sanitizeNote('Monthly salary')).toBe('Monthly salary');
+  });
+
+  it('should preserve Hebrew text', () => {
+    expect(sanitizeNote('משכורת חודשית')).toBe('משכורת חודשית');
+  });
+});
+
+// ========================================================================
+// validateImportEntry
+// ========================================================================
+describe('validateImportEntry', () => {
+  it('should validate a complete valid entry', () => {
+    const raw = { type: 'income', amount: 1000, date: '2026-03-15', note: 'salary' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry.type).toBe('income');
+    expect(result.entry.amount).toBe(1000);
+    expect(result.entry.date).toBe('2026-03-15');
+    expect(result.entry.note).toBe('salary');
+  });
+
+  it('should validate entry with Hebrew type', () => {
+    const raw = { type: 'הכנסה', amount: 500, date: '2026-03-15' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry.type).toBe('income');
+  });
+
+  it('should coerce string amount', () => {
+    const raw = { type: 'income', amount: '1,000.50', date: '2026-03-15' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry.amount).toBe(1000.50);
+  });
+
+  it('should parse DD/MM/YYYY date', () => {
+    const raw = { type: 'income', amount: 100, date: '15/03/2026' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry.date).toBe('2026-03-15');
+  });
+
+  it('should strip dangerous keys from entry', () => {
+    const raw = {
+      type: 'income',
+      amount: 100,
+      date: '2026-03-15',
+      '__proto__': { polluted: true },
+    };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry).not.toHaveProperty('__proto__');
+  });
+
+  it('should omit note when empty', () => {
+    const raw = { type: 'income', amount: 100, date: '2026-03-15' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(true);
+    expect(result.entry.note).toBeUndefined();
+  });
+
+  it('should reject null entry', () => {
+    const result = validateImportEntry(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Entry must be an object');
+  });
+
+  it('should collect multiple errors', () => {
+    const raw = { type: 'invalid', amount: -1, date: '' };
+    const result = validateImportEntry(raw);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(1);
+  });
+});
+
+// ========================================================================
+// parseJSONFile
+// ========================================================================
+describe('parseJSONFile', () => {
+  it('should parse a valid JSON file with schema v1 envelope', async () => {
+    const data = {
+      version: 1,
+      exportedAt: '2026-03-15T00:00:00Z',
+      entries: [
+        { type: 'income', amount: 1000, date: '2026-03-15', note: 'salary' },
+        { type: 'donation', amount: 100, date: '2026-03-16' },
+      ],
+    };
+    const file = createMockFile(JSON.stringify(data), 'export.json');
+    const result = await parseJSONFile(file);
+    expect(result.validEntries).toHaveLength(2);
+    expect(result.invalidEntries).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should handle BOM in JSON file', async () => {
+    const data = {
+      version: 1,
+      entries: [{ type: 'income', amount: 100, date: '2026-03-15' }],
+    };
+    const file = createMockFile('\uFEFF' + JSON.stringify(data), 'bom.json');
+    const result = await parseJSONFile(file);
+    expect(result.validEntries).toHaveLength(1);
+  });
+
+  it('should reject file exceeding size limit', async () => {
+    const file = createMockFile('{}', 'huge.json', FILE_SIZE_LIMIT + 1);
+    const result = await parseJSONFile(file);
+    expect(result.validEntries).toHaveLength(0);
+    expect(result.errors[0]).toContain('exceeds maximum limit');
+  });
+
+  it('should warn for large files below limit', async () => {
+    const data = {
+      version: 1,
+      entries: [{ type: 'income', amount: 100, date: '2026-03-15' }],
+    };
+    const file = createMockFile(JSON.stringify(data), 'big.json', FILE_SIZE_WARNING + 1);
+    const result = await parseJSONFile(file);
+    expect(result.warnings).toContain('File is large and may take a while to process');
+  });
+
+  it('should reject invalid JSON syntax', async () => {
+    const file = createMockFile('{ not valid json', 'bad.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('Invalid JSON format');
+  });
+
+  it('should reject wrong schema version', async () => {
+    const data = { version: 99, entries: [] };
+    const file = createMockFile(JSON.stringify(data), 'wrong.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors[0]).toContain('Unsupported schema version');
+  });
+
+  it('should reject missing entries array', async () => {
+    const data = { version: 1 };
+    const file = createMockFile(JSON.stringify(data), 'missing.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('JSON must contain an "entries" array');
+  });
+
+  it('should reject empty entries array', async () => {
+    const data = { version: 1, entries: [] };
+    const file = createMockFile(JSON.stringify(data), 'empty.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('No entries found in file');
+  });
+
+  it('should separate valid and invalid entries', async () => {
+    const data = {
+      version: 1,
+      entries: [
+        { type: 'income', amount: 1000, date: '2026-03-15' },
+        { type: 'invalid', amount: -1, date: '' },
+        { type: 'donation', amount: 200, date: '2026-03-16' },
+      ],
+    };
+    const file = createMockFile(JSON.stringify(data), 'mixed.json');
+    const result = await parseJSONFile(file);
+    expect(result.validEntries).toHaveLength(2);
+    expect(result.invalidEntries).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Entry 2');
+  });
+
+  it('should sanitize prototype pollution in JSON', async () => {
+    const json = '{"version":1,"entries":[{"type":"income","amount":100,"date":"2026-03-15","__proto__":{"admin":true}}]}';
+    const file = createMockFile(json, 'pollution.json');
+    const result = await parseJSONFile(file);
+    expect(result.validEntries).toHaveLength(1);
+    expect(result.validEntries[0]).not.toHaveProperty('admin');
+  });
+
+  it('should reject non-object JSON (array)', async () => {
+    const file = createMockFile('[1,2,3]', 'array.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('JSON must be an object with version and entries');
+  });
+
+  it('should reject non-object JSON (string)', async () => {
+    const file = createMockFile('"just a string"', 'string.json');
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('JSON must be an object with version and entries');
+  });
+
+  it('should handle file read failure gracefully', async () => {
+    const file = {
+      size: 100,
+      text: vi.fn().mockRejectedValue(new Error('read error')),
+    };
+    const result = await parseJSONFile(file);
+    expect(result.errors).toContain('Failed to read file');
+  });
+});
+
+// ========================================================================
+// parseCSVFile
+// ========================================================================
+describe('parseCSVFile', () => {
+  it('should parse a valid CSV with English headers', async () => {
+    const csv = 'type,amount,date,note\nincome,1000,2026-03-15,salary\ndonation,100,2026-03-16,charity';
+    const file = createMockFile(csv, 'export.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(2);
+    expect(result.validEntries[0].type).toBe('income');
+    expect(result.validEntries[0].amount).toBe(1000);
+    expect(result.validEntries[0].date).toBe('2026-03-15');
+    expect(result.validEntries[0].note).toBe('salary');
+  });
+
+  it('should parse CSV with Hebrew headers', async () => {
+    const csv = 'סוג,סכום,תאריך,הערה\nהכנסה,1000,15/03/2026,משכורת';
+    const file = createMockFile(csv, 'hebrew.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(1);
+    expect(result.validEntries[0].type).toBe('income');
+    expect(result.validEntries[0].amount).toBe(1000);
+    expect(result.validEntries[0].date).toBe('2026-03-15');
+  });
+
+  it('should handle BOM in CSV', async () => {
+    const csv = '\uFEFFtype,amount,date\nincome,100,2026-03-15';
+    const file = createMockFile(csv, 'bom.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(1);
+  });
+
+  it('should reject file exceeding size limit', async () => {
+    const file = createMockFile('type,amount,date', 'huge.csv', FILE_SIZE_LIMIT + 1);
+    const result = await parseCSVFile(file);
+    expect(result.errors[0]).toContain('exceeds maximum limit');
+  });
+
+  it('should report missing required columns', async () => {
+    const csv = 'name,value\ntest,100';
+    const file = createMockFile(csv, 'missing.csv');
+    const result = await parseCSVFile(file);
+    expect(result.errors[0]).toContain('Missing required columns');
+    expect(result.errors[0]).toContain('type');
+    expect(result.errors[0]).toContain('amount');
+    expect(result.errors[0]).toContain('date');
+  });
+
+  it('should separate valid and invalid CSV rows', async () => {
+    const csv = 'type,amount,date\nincome,1000,2026-03-15\ninvalid,-1,\ndonation,200,2026-03-16';
+    const file = createMockFile(csv, 'mixed.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(2);
+    expect(result.invalidEntries).toHaveLength(1);
+  });
+
+  it('should report unmapped columns as warnings', async () => {
+    const csv = 'type,amount,date,extra_col\nincome,100,2026-03-15,foo';
+    const file = createMockFile(csv, 'extra.csv');
+    const result = await parseCSVFile(file);
+    expect(result.warnings.some((w) => w.includes('Unmapped columns'))).toBe(true);
+  });
+
+  it('should handle file read failure gracefully', async () => {
+    const file = {
+      size: 100,
+      text: vi.fn().mockRejectedValue(new Error('read error')),
+    };
+    const result = await parseCSVFile(file);
+    expect(result.errors).toContain('Failed to read file');
+  });
+
+  it('should parse CSV with semicolon delimiter', async () => {
+    const csv = 'type;amount;date\nincome;1000;2026-03-15';
+    const file = createMockFile(csv, 'semicolon.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(1);
+  });
+
+  it('should handle empty CSV (no data rows)', async () => {
+    const csv = 'type,amount,date\n';
+    const file = createMockFile(csv, 'empty.csv');
+    const result = await parseCSVFile(file);
+    expect(result.errors.some((e) => e.includes('No data rows'))).toBe(true);
+  });
+
+  it('should handle comma in amount with CSV quoting', async () => {
+    const csv = 'type,amount,date\nincome,"1,000",2026-03-15';
+    const file = createMockFile(csv, 'quoted.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(1);
+    expect(result.validEntries[0].amount).toBe(1000);
+  });
+
+  it('should handle CSV with CRLF line endings', async () => {
+    const csv = 'type,amount,date\r\nincome,100,2026-03-15\r\ndonation,50,2026-03-16\r\n';
+    const file = createMockFile(csv, 'crlf.csv');
+    const result = await parseCSVFile(file);
+    expect(result.validEntries).toHaveLength(2);
+  });
+});
+
+// ========================================================================
+// Constants validation
+// ========================================================================
+describe('constants', () => {
+  it('should export correct FILE_SIZE_WARNING (5MB)', () => {
+    expect(FILE_SIZE_WARNING).toBe(5 * 1024 * 1024);
+  });
+
+  it('should export correct FILE_SIZE_LIMIT (10MB)', () => {
+    expect(FILE_SIZE_LIMIT).toBe(10 * 1024 * 1024);
+  });
+
+  it('should export SCHEMA_VERSION as 1', () => {
+    expect(SCHEMA_VERSION).toBe(1);
+  });
+
+  it('should export HEBREW_HEADER_MAP with all required mappings', () => {
+    expect(HEBREW_HEADER_MAP['סוג']).toBe('type');
+    expect(HEBREW_HEADER_MAP['סכום']).toBe('amount');
+    expect(HEBREW_HEADER_MAP['תאריך']).toBe('date');
+    expect(HEBREW_HEADER_MAP['הערה']).toBe('note');
+    expect(HEBREW_HEADER_MAP['מעשר']).toBe('maaser');
+  });
+
+  it('should export HEBREW_TYPE_MAP with all required mappings', () => {
+    expect(HEBREW_TYPE_MAP['הכנסה']).toBe('income');
+    expect(HEBREW_TYPE_MAP['תרומה']).toBe('donation');
+    expect(HEBREW_TYPE_MAP['מעשר']).toBe('maaser');
+  });
+});
+
+// ========================================================================
+// Import Engine Tests
+// ========================================================================
+
+// Mock dependencies for import engine
+vi.mock('../db', () => ({
+  addEntry: vi.fn().mockResolvedValue('mock-id'),
+  getAllEntries: vi.fn().mockResolvedValue([]),
+  clearAllEntries: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../exportService', () => ({
+  exportToJSON: vi.fn().mockReturnValue('{"version":1,"entries":[]}'),
+  downloadFile: vi.fn().mockReturnValue({ downloaded: true, iosSafari: false }),
+  generateFilename: vi.fn().mockReturnValue('maaser-tracker-2026-03-09.json'),
+}));
+
+// Import mocked modules so we can control them
+import { addEntry, getAllEntries, clearAllEntries } from '../db';
+import { exportToJSON, downloadFile } from '../exportService';
+
+// Helper: make a validated entry (output of parseJSONFile/parseCSVFile)
+function makeValidatedEntry(overrides = {}) {
+  return {
+    type: 'income',
+    amount: 1000,
+    date: '2026-03-15',
+    note: 'salary',
+    ...overrides,
+  };
+}
+
+// ========================================================================
+// Constants
+// ========================================================================
+describe('Import Engine Constants', () => {
+  it('should export IMPORT_MODE_MERGE as "merge"', () => {
+    expect(IMPORT_MODE_MERGE).toBe('merge');
+  });
+
+  it('should export IMPORT_MODE_REPLACE as "replace"', () => {
+    expect(IMPORT_MODE_REPLACE).toBe('replace');
+  });
+
+  it('should export INDEXEDDB_BATCH_SIZE as 100', () => {
+    expect(INDEXEDDB_BATCH_SIZE).toBe(100);
+  });
+});
+
+// ========================================================================
+// prepareEntryForStorage
+// ========================================================================
+describe('prepareEntryForStorage', () => {
+  beforeEach(() => {
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid-001');
+  });
+
+  it('should assign a new UUID to the entry', () => {
+    const entry = makeValidatedEntry();
+    const prepared = prepareEntryForStorage(entry);
+    expect(prepared.id).toBe('test-uuid-001');
+  });
+
+  it('should compute accountingMonth from date', () => {
+    const entry = makeValidatedEntry({ date: '2026-03-15' });
+    const prepared = prepareEntryForStorage(entry);
+    expect(prepared.accountingMonth).toBe('2026-03');
+  });
+
+  it('should preserve type, amount, date, and note', () => {
+    const entry = makeValidatedEntry({ type: 'donation', amount: 500, date: '2026-01-20', note: 'charity' });
+    const prepared = prepareEntryForStorage(entry);
+    expect(prepared.type).toBe('donation');
+    expect(prepared.amount).toBe(500);
+    expect(prepared.date).toBe('2026-01-20');
+    expect(prepared.note).toBe('charity');
+  });
+
+  it('should default note to empty string when undefined', () => {
+    const entry = makeValidatedEntry({ note: undefined });
+    const prepared = prepareEntryForStorage(entry);
+    expect(prepared.note).toBe('');
+  });
+});
+
+// ========================================================================
+// createAutoBackup
+// ========================================================================
+describe('createAutoBackup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return success with zero count for empty entries', () => {
+    const result = createAutoBackup([]);
+    expect(result.success).toBe(true);
+    expect(result.entryCount).toBe(0);
+    expect(result.error).toBeNull();
+  });
+
+  it('should return success with zero count for null entries', () => {
+    const result = createAutoBackup(null);
+    expect(result.success).toBe(true);
+    expect(result.entryCount).toBe(0);
+  });
+
+  it('should export and download JSON backup', () => {
+    const entries = [{ id: '1', type: 'income', amount: 1000, date: '2026-03-15' }];
+    const result = createAutoBackup(entries);
+    expect(result.success).toBe(true);
+    expect(result.entryCount).toBe(1);
+    expect(exportToJSON).toHaveBeenCalledWith(entries);
+    expect(downloadFile).toHaveBeenCalled();
+    expect(downloadFile.mock.calls[0][1]).toContain('backup-before-import-');
+  });
+
+  it('should return error if export fails', () => {
+    exportToJSON.mockImplementationOnce(() => { throw new Error('export failed'); });
+    const entries = [{ id: '1', type: 'income', amount: 1000, date: '2026-03-15' }];
+    const result = createAutoBackup(entries);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('export failed');
+  });
+});
+
+// ========================================================================
+// batchWriteIndexedDB
+// ========================================================================
+describe('batchWriteIndexedDB', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addEntry.mockResolvedValue('mock-id');
+  });
+
+  it('should write all entries and return written count', async () => {
+    const entries = [
+      { id: '1', type: 'income', amount: 100, date: '2026-03-01', note: '', accountingMonth: '2026-03' },
+      { id: '2', type: 'donation', amount: 50, date: '2026-03-02', note: '', accountingMonth: '2026-03' },
+    ];
+    const result = await batchWriteIndexedDB(entries);
+    expect(result.written).toBe(2);
+    expect(result.failed).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+    expect(addEntry).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call onProgress after each batch', async () => {
+    const entries = Array.from({ length: 3 }, (_, i) => ({
+      id: `e-${i}`, type: 'income', amount: 100, date: '2026-03-01', note: '', accountingMonth: '2026-03',
+    }));
+    const onProgress = vi.fn();
+    await batchWriteIndexedDB(entries, { batchSize: 2, onProgress });
+    // Two batches: batch 1 (0-1), batch 2 (2)
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenCalledWith({ current: 2, total: 3, phase: 'importing' });
+    expect(onProgress).toHaveBeenCalledWith({ current: 3, total: 3, phase: 'importing' });
+  });
+
+  it('should continue writing after a failed entry in the batch', async () => {
+    addEntry
+      .mockResolvedValueOnce('ok')
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce('ok');
+
+    const entries = [
+      { id: '1', type: 'income', amount: 100, date: '2026-03-01', note: '', accountingMonth: '2026-03' },
+      { id: '2', type: 'income', amount: 200, date: '2026-03-02', note: '', accountingMonth: '2026-03' },
+      { id: '3', type: 'income', amount: 300, date: '2026-03-03', note: '', accountingMonth: '2026-03' },
+    ];
+    const result = await batchWriteIndexedDB(entries);
+    expect(result.written).toBe(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].entry.id).toBe('2');
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('should respect custom batch size', async () => {
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      id: `e-${i}`, type: 'income', amount: 100, date: '2026-03-01', note: '', accountingMonth: '2026-03',
+    }));
+    const onProgress = vi.fn();
+    await batchWriteIndexedDB(entries, { batchSize: 3, onProgress });
+    // 2 batches: [0,1,2] and [3,4]
+    expect(onProgress).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle empty entries array', async () => {
+    const result = await batchWriteIndexedDB([]);
+    expect(result.written).toBe(0);
+    expect(result.failed).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ========================================================================
+// mergeEntries
+// ========================================================================
+describe('mergeEntries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addEntry.mockResolvedValue('mock-id');
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('merge-uuid-001');
+  });
+
+  it('should import entries with new UUIDs in merge mode', async () => {
+    const entries = [makeValidatedEntry(), makeValidatedEntry({ type: 'donation', amount: 200 })];
+    const result = await mergeEntries(entries);
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(2);
+    expect(result.failed).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should fire progress callbacks through phases', async () => {
+    const entries = [makeValidatedEntry()];
+    const onProgress = vi.fn();
+    await mergeEntries(entries, { onProgress });
+    const phases = onProgress.mock.calls.map((c) => c[0].phase);
+    expect(phases).toContain('validating');
+    expect(phases).toContain('importing');
+    expect(phases).toContain('complete');
+  });
+
+  it('should return error for empty entries', async () => {
+    const result = await mergeEntries([]);
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No entries to import');
+  });
+
+  it('should return error for null entries', async () => {
+    const result = await mergeEntries(null);
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No entries to import');
+  });
+
+  it('should report partial failures without stopping', async () => {
+    addEntry
+      .mockResolvedValueOnce('ok')
+      .mockRejectedValueOnce(new Error('db error'))
+      .mockResolvedValueOnce('ok');
+
+    const entries = [makeValidatedEntry(), makeValidatedEntry(), makeValidatedEntry()];
+    const result = await mergeEntries(entries);
+    expect(result.success).toBe(false);
+    expect(result.imported).toBe(2);
+    expect(result.failed).toHaveLength(1);
+  });
+});
+
+// ========================================================================
+// replaceAllEntries
+// ========================================================================
+describe('replaceAllEntries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addEntry.mockResolvedValue('mock-id');
+    getAllEntries.mockResolvedValue([]);
+    clearAllEntries.mockResolvedValue(undefined);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('replace-uuid-001');
+  });
+
+  it('should clear existing entries and import new ones', async () => {
+    const entries = [makeValidatedEntry()];
+    const result = await replaceAllEntries(entries, { skipBackup: true });
+    expect(clearAllEntries).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+  });
+
+  it('should create auto-backup before clearing when entries exist', async () => {
+    getAllEntries.mockResolvedValue([{ id: 'old-1', type: 'income', amount: 500, date: '2026-01-01' }]);
+    const entries = [makeValidatedEntry()];
+    const result = await replaceAllEntries(entries);
+    expect(exportToJSON).toHaveBeenCalled();
+    expect(downloadFile).toHaveBeenCalled();
+    expect(result.backedUp).toBe(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('should skip backup when skipBackup option is true', async () => {
+    getAllEntries.mockResolvedValue([{ id: 'old-1', type: 'income', amount: 500, date: '2026-01-01' }]);
+    const entries = [makeValidatedEntry()];
+    await replaceAllEntries(entries, { skipBackup: true });
+    expect(getAllEntries).not.toHaveBeenCalled();
+    expect(exportToJSON).not.toHaveBeenCalled();
+  });
+
+  it('should abort if backup fails', async () => {
+    getAllEntries.mockResolvedValue([{ id: 'old-1', type: 'income', amount: 500, date: '2026-01-01' }]);
+    exportToJSON.mockImplementationOnce(() => { throw new Error('export error'); });
+    const entries = [makeValidatedEntry()];
+    const result = await replaceAllEntries(entries);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Auto-backup failed');
+    expect(clearAllEntries).not.toHaveBeenCalled();
+  });
+
+  it('should abort if getAllEntries fails during backup', async () => {
+    getAllEntries.mockRejectedValueOnce(new Error('db read error'));
+    const entries = [makeValidatedEntry()];
+    const result = await replaceAllEntries(entries);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Failed to read existing entries');
+  });
+
+  it('should abort if clearAllEntries fails', async () => {
+    clearAllEntries.mockRejectedValueOnce(new Error('clear error'));
+    const entries = [makeValidatedEntry()];
+    const result = await replaceAllEntries(entries, { skipBackup: true });
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Failed to clear existing entries');
+  });
+
+  it('should fire progress callbacks through all phases', async () => {
+    getAllEntries.mockResolvedValue([{ id: 'old', type: 'income', amount: 100, date: '2026-01-01' }]);
+    const entries = [makeValidatedEntry()];
+    const onProgress = vi.fn();
+    await replaceAllEntries(entries, { onProgress });
+    const phases = onProgress.mock.calls.map((c) => c[0].phase);
+    expect(phases).toContain('validating');
+    expect(phases).toContain('backing-up');
+    expect(phases).toContain('clearing');
+    expect(phases).toContain('importing');
+    expect(phases).toContain('complete');
+  });
+
+  it('should return error for empty entries', async () => {
+    const result = await replaceAllEntries([]);
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No entries to import');
+  });
+});
+
+// ========================================================================
+// importEntries (orchestrator)
+// ========================================================================
+describe('importEntries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addEntry.mockResolvedValue('mock-id');
+    getAllEntries.mockResolvedValue([]);
+    clearAllEntries.mockResolvedValue(undefined);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('import-uuid-001');
+  });
+
+  it('should default to merge mode', async () => {
+    const entries = [makeValidatedEntry()];
+    const result = await importEntries(entries);
+    expect(result.mode).toBe('merge');
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+    expect(result.backedUp).toBe(0);
+  });
+
+  it('should use replace mode when specified', async () => {
+    const entries = [makeValidatedEntry()];
+    const result = await importEntries(entries, IMPORT_MODE_REPLACE, { skipBackup: true });
+    expect(result.mode).toBe('replace');
+    expect(result.success).toBe(true);
+    expect(clearAllEntries).toHaveBeenCalled();
+  });
+
+  it('should reject invalid mode', async () => {
+    const entries = [makeValidatedEntry()];
+    const result = await importEntries(entries, 'invalid-mode');
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain('Invalid import mode');
+  });
+
+  it('should reject empty entries', async () => {
+    const result = await importEntries([]);
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No entries to import');
+  });
+
+  it('should reject null entries', async () => {
+    const result = await importEntries(null);
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('No entries to import');
+  });
+
+  it('should pass onProgress option through to merge', async () => {
+    const entries = [makeValidatedEntry()];
+    const onProgress = vi.fn();
+    await importEntries(entries, IMPORT_MODE_MERGE, { onProgress });
+    expect(onProgress).toHaveBeenCalled();
+    const phases = onProgress.mock.calls.map((c) => c[0].phase);
+    expect(phases).toContain('complete');
+  });
+
+  it('should pass onProgress option through to replace', async () => {
+    const entries = [makeValidatedEntry()];
+    const onProgress = vi.fn();
+    await importEntries(entries, IMPORT_MODE_REPLACE, { onProgress, skipBackup: true });
+    expect(onProgress).toHaveBeenCalled();
+  });
+});

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -1,0 +1,175 @@
+/**
+ * Export Service for Ma'aser Tracker
+ *
+ * Provides JSON and CSV export functionality for entry data.
+ * CSV uses PapaParse (dynamic import) with UTF-8 BOM for Hebrew Excel compatibility.
+ * Includes formula injection prevention for CSV cells.
+ */
+
+/** Current export schema version */
+const EXPORT_SCHEMA_VERSION = 1;
+
+/** Internal fields that should be stripped from exported entries */
+const INTERNAL_FIELDS = ['createdAt', 'updatedAt', 'userId'];
+
+/** Characters that trigger formula execution in spreadsheet applications */
+const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@'];
+
+/** UTF-8 BOM for Excel Hebrew compatibility */
+const UTF8_BOM = '\uFEFF';
+
+/** CSV column headers (English) */
+const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'note', 'accountingMonth'];
+
+/**
+ * Strip internal/server-side fields from an entry for export.
+ * @param {Object} entry - Entry object potentially containing internal fields
+ * @returns {Object} Entry with internal fields removed
+ */
+function stripInternalFields(entry) {
+  const cleaned = { ...entry };
+  for (const field of INTERNAL_FIELDS) {
+    delete cleaned[field];
+  }
+  return cleaned;
+}
+
+/**
+ * Sanitize a cell value to prevent CSV formula injection.
+ * Prefixes cells starting with =, +, -, @ with a single quote.
+ * @param {*} value - Cell value to sanitize
+ * @returns {*} Sanitized value (string if prefixed, original otherwise)
+ */
+function sanitizeCsvCell(value) {
+  if (typeof value !== 'string') return value;
+  if (value.length === 0) return value;
+  if (FORMULA_TRIGGER_CHARS.includes(value[0])) {
+    return "'" + value;
+  }
+  return value;
+}
+
+/**
+ * Sanitize all string fields in an entry for CSV export.
+ * @param {Object} entry - Entry object
+ * @returns {Object} Entry with sanitized string fields
+ */
+function sanitizeEntryForCsv(entry) {
+  const sanitized = {};
+  for (const [key, value] of Object.entries(entry)) {
+    sanitized[key] = sanitizeCsvCell(value);
+  }
+  return sanitized;
+}
+
+/**
+ * Generate a filename for export.
+ * @param {'json' | 'csv'} format - Export format
+ * @returns {string} Filename in format: maaser-tracker-YYYY-MM-DD.{json|csv}
+ */
+export function generateFilename(format) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `maaser-tracker-${year}-${month}-${day}.${format}`;
+}
+
+/**
+ * Export entries to JSON format with a schema v1 envelope.
+ * Strips internal fields (createdAt, updatedAt, userId) from entries.
+ *
+ * @param {Array<Object>} entries - Array of entry objects to export
+ * @returns {string} JSON string with schema envelope
+ * @throws {Error} If entries is empty or not an array
+ */
+export function exportToJSON(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('No entries to export');
+  }
+
+  const cleanedEntries = entries.map(stripInternalFields);
+
+  const envelope = {
+    version: EXPORT_SCHEMA_VERSION,
+    exportDate: new Date().toISOString(),
+    entryCount: cleanedEntries.length,
+    entries: cleanedEntries,
+  };
+
+  return JSON.stringify(envelope, null, 2);
+}
+
+/**
+ * Export entries to CSV format using PapaParse.
+ * Includes UTF-8 BOM prefix for Hebrew Excel compatibility.
+ * Prevents formula injection by prefixing dangerous cell values.
+ * PapaParse is loaded via dynamic import to enable code splitting.
+ *
+ * @param {Array<Object>} entries - Array of entry objects to export
+ * @returns {Promise<string>} CSV string with UTF-8 BOM prefix
+ * @throws {Error} If entries is empty or not an array
+ */
+export async function exportToCSV(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('No entries to export');
+  }
+
+  const Papa = await import('papaparse');
+
+  const cleanedEntries = entries.map(stripInternalFields);
+  const sanitizedEntries = cleanedEntries.map(sanitizeEntryForCsv);
+
+  const csv = Papa.default.unparse(sanitizedEntries, {
+    columns: CSV_HEADERS,
+    header: true,
+  });
+
+  return UTF8_BOM + csv;
+}
+
+/**
+ * Detect if the current browser is iOS Safari.
+ * On iOS Safari, programmatic download is unreliable.
+ * @returns {boolean} True if running on iOS Safari
+ */
+function isIOSSafari() {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
+  const isSafari = /^((?!chrome|android).)*safari/i.test(ua);
+  return isIOS && isSafari;
+}
+
+/**
+ * Trigger a file download in the browser.
+ * Creates a temporary Blob URL, clicks an anchor element, then revokes the URL.
+ * On iOS Safari, opens the content in a new tab with a save instruction.
+ *
+ * @param {string} content - File content to download
+ * @param {string} filename - Name for the downloaded file
+ * @param {string} mimeType - MIME type of the content (e.g., 'application/json', 'text/csv')
+ * @returns {{ downloaded: boolean, iosSafari: boolean }} Result indicating download method used
+ */
+export function downloadFile(content, filename, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  if (isIOSSafari()) {
+    window.open(url, '_blank');
+    // Revoke after a delay to allow the new tab to load
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+    return { downloaded: true, iosSafari: true };
+  }
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+
+  return { downloaded: true, iosSafari: false };
+}

--- a/src/services/importService.js
+++ b/src/services/importService.js
@@ -1,0 +1,938 @@
+/**
+ * Import Service for Ma'aser Tracker
+ *
+ * Parses and validates JSON and CSV files for import.
+ * Handles Hebrew/English column mapping, date format detection,
+ * amount coercion, and security sanitization.
+ *
+ * Import Engine (batch write & conflict resolution):
+ * - Two modes: MERGE (add alongside existing) and REPLACE (clear + add)
+ * - Batch processing: 100 entries/batch for IndexedDB
+ * - Progress callbacks for UI updates
+ * - Auto-backup before Replace mode
+ * - Maaser recalculation after import
+ */
+
+import { NOTE_MAX_LENGTH, getAccountingMonthFromDate } from './validation';
+import { addEntry, getAllEntries, clearAllEntries } from './db';
+import { exportToJSON, downloadFile, generateFilename } from './exportService';
+
+// --- Constants ---
+
+/** Soft warning threshold in bytes (5 MB) */
+export const FILE_SIZE_WARNING = 5 * 1024 * 1024;
+
+/** Hard rejection threshold in bytes (10 MB) */
+export const FILE_SIZE_LIMIT = 10 * 1024 * 1024;
+
+/** Current schema version for JSON export/import */
+export const SCHEMA_VERSION = 1;
+
+/** Valid entry type values */
+const VALID_TYPES = ['income', 'donation', 'maaser'];
+
+/** Keys considered dangerous for prototype pollution */
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Hebrew-to-English column header mapping.
+ * Keys are lowercase-trimmed Hebrew headers; values are internal field names.
+ */
+export const HEBREW_HEADER_MAP = {
+  'סוג': 'type',
+  'סכום': 'amount',
+  'תאריך': 'date',
+  'הערה': 'note',
+  'הערות': 'note',
+  'מעשר': 'maaser',
+  'מזהה': 'id',
+};
+
+/**
+ * English-to-internal column header mapping (case-insensitive).
+ */
+const ENGLISH_HEADER_MAP = {
+  'type': 'type',
+  'amount': 'amount',
+  'date': 'date',
+  'note': 'note',
+  'notes': 'note',
+  'maaser': 'maaser',
+  'id': 'id',
+};
+
+/**
+ * Hebrew type value mapping to internal values.
+ */
+export const HEBREW_TYPE_MAP = {
+  'הכנסה': 'income',
+  'תרומה': 'donation',
+  'מעשר': 'maaser',
+};
+
+// --- File Size Validation ---
+
+/**
+ * Validate file size against limits.
+ * @param {File} file - File object to check
+ * @returns {{ valid: boolean, warning: boolean, error: string|null }}
+ */
+export function validateFileSize(file) {
+  if (!file || typeof file.size !== 'number') {
+    return { valid: false, warning: false, error: 'Invalid file object' };
+  }
+
+  if (file.size > FILE_SIZE_LIMIT) {
+    return {
+      valid: false,
+      warning: false,
+      error: `File size (${formatBytes(file.size)}) exceeds maximum limit of ${formatBytes(FILE_SIZE_LIMIT)}`,
+    };
+  }
+
+  if (file.size > FILE_SIZE_WARNING) {
+    return {
+      valid: true,
+      warning: true,
+      error: null,
+    };
+  }
+
+  return { valid: true, warning: false, error: null };
+}
+
+/**
+ * Format bytes to human-readable string.
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(1)} MB`;
+}
+
+// --- BOM Stripping ---
+
+/**
+ * Strip UTF-8 BOM from text content.
+ * @param {string} text - Raw text that may contain BOM
+ * @returns {string} Text without BOM
+ */
+export function stripBOM(text) {
+  if (typeof text !== 'string') return text;
+  if (text.charCodeAt(0) === 0xFEFF) {
+    return text.slice(1);
+  }
+  return text;
+}
+
+// --- Security: Prototype Pollution Protection ---
+
+/**
+ * Recursively strip dangerous keys from an object to prevent prototype pollution.
+ * @param {*} obj - Object to sanitize
+ * @returns {*} Sanitized object (new copy)
+ */
+export function sanitizeObject(obj) {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(sanitizeObject);
+
+  const clean = {};
+  for (const key of Object.keys(obj)) {
+    if (DANGEROUS_KEYS.includes(key)) continue;
+    clean[key] = sanitizeObject(obj[key]);
+  }
+  return clean;
+}
+
+// --- Date Parsing ---
+
+/**
+ * Detect and parse a date value into ISO format (YYYY-MM-DD).
+ *
+ * Tries formats in order:
+ * 1. ISO 8601 (YYYY-MM-DD or full ISO string)
+ * 2. DD/MM/YYYY (Israeli locale default)
+ * 3. MM/DD/YYYY
+ *
+ * @param {string} value - Date string to parse
+ * @returns {{ date: string|null, format: string|null, error: string|null }}
+ */
+export function parseDateValue(value) {
+  if (!value || typeof value !== 'string') {
+    return { date: null, format: null, error: 'Date value is required' };
+  }
+
+  const trimmed = value.trim();
+
+  // Try ISO 8601: YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss...
+  const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    if (isValidDateParts(year, month, day)) {
+      return { date: `${year}-${month}-${day}`, format: 'ISO', error: null };
+    }
+  }
+
+  // Try DD/MM/YYYY or DD.MM.YYYY or DD-MM-YYYY
+  const ddmmMatch = trimmed.match(/^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$/);
+  if (ddmmMatch) {
+    const [, part1, part2, year] = ddmmMatch;
+    const day = part1.padStart(2, '0');
+    const month = part2.padStart(2, '0');
+
+    // Try DD/MM/YYYY first (Israeli default)
+    if (isValidDateParts(year, month, day)) {
+      return {
+        date: `${year}-${month}-${day}`,
+        format: 'DD/MM/YYYY',
+        error: null,
+      };
+    }
+
+    // Try MM/DD/YYYY
+    const altDay = part2.padStart(2, '0');
+    const altMonth = part1.padStart(2, '0');
+    if (isValidDateParts(year, altMonth, altDay)) {
+      return {
+        date: `${year}-${altMonth}-${altDay}`,
+        format: 'MM/DD/YYYY',
+        error: null,
+      };
+    }
+  }
+
+  return { date: null, format: null, error: `Unable to parse date: "${trimmed}"` };
+}
+
+/**
+ * Validate date parts are within valid ranges.
+ * @param {string} year
+ * @param {string} month
+ * @param {string} day
+ * @returns {boolean}
+ */
+function isValidDateParts(year, month, day) {
+  const y = parseInt(year, 10);
+  const m = parseInt(month, 10);
+  const d = parseInt(day, 10);
+
+  if (y < 1900 || y > 2100) return false;
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+
+  // Validate actual date (handles Feb 30, etc.)
+  const testDate = new Date(y, m - 1, d);
+  return (
+    testDate.getFullYear() === y &&
+    testDate.getMonth() === m - 1 &&
+    testDate.getDate() === d
+  );
+}
+
+// --- Header Mapping ---
+
+/**
+ * Map CSV headers (Hebrew or English) to internal field names.
+ * @param {string[]} headers - Raw header strings from CSV
+ * @returns {{ mapped: Record<string, string>, unmapped: string[] }}
+ */
+export function mapCSVHeaders(headers) {
+  if (!Array.isArray(headers)) {
+    return { mapped: {}, unmapped: [] };
+  }
+
+  const mapped = {};
+  const unmapped = [];
+
+  for (const header of headers) {
+    const trimmed = (header || '').trim();
+    const lower = trimmed.toLowerCase();
+
+    // Try Hebrew mapping first
+    const hebrewMatch = HEBREW_HEADER_MAP[trimmed];
+    if (hebrewMatch) {
+      mapped[header] = hebrewMatch;
+      continue;
+    }
+
+    // Try English mapping (case-insensitive)
+    const englishMatch = ENGLISH_HEADER_MAP[lower];
+    if (englishMatch) {
+      mapped[header] = englishMatch;
+      continue;
+    }
+
+    unmapped.push(header);
+  }
+
+  return { mapped, unmapped };
+}
+
+// --- Amount Coercion ---
+
+/**
+ * Parse and coerce an amount value to a valid positive number.
+ * Handles string amounts, comma-separated numbers (e.g., "1,000.50").
+ * @param {*} value - Amount value to coerce
+ * @returns {{ amount: number|null, error: string|null }}
+ */
+export function parseAmount(value) {
+  if (value === null || value === undefined || value === '') {
+    return { amount: null, error: 'Amount is required' };
+  }
+
+  let num;
+
+  if (typeof value === 'number') {
+    num = value;
+  } else if (typeof value === 'string') {
+    // Remove commas used as thousand separators
+    const cleaned = value.trim().replace(/,/g, '');
+    num = Number(cleaned);
+  } else {
+    return { amount: null, error: 'Amount must be a number or numeric string' };
+  }
+
+  if (!Number.isFinite(num)) {
+    return { amount: null, error: 'Amount must be a finite number' };
+  }
+
+  if (num <= 0) {
+    return { amount: null, error: 'Amount must be positive' };
+  }
+
+  return { amount: num, error: null };
+}
+
+// --- Type Mapping ---
+
+/**
+ * Map a type value (Hebrew or English) to an internal type.
+ * @param {string} value - Raw type value
+ * @returns {{ type: string|null, error: string|null }}
+ */
+export function mapTypeValue(value) {
+  if (!value || typeof value !== 'string') {
+    return { type: null, error: 'Type is required' };
+  }
+
+  const trimmed = value.trim();
+  const lower = trimmed.toLowerCase();
+
+  // Direct English match
+  if (VALID_TYPES.includes(lower)) {
+    return { type: lower, error: null };
+  }
+
+  // Hebrew match
+  const hebrewMatch = HEBREW_TYPE_MAP[trimmed];
+  if (hebrewMatch) {
+    return { type: hebrewMatch, error: null };
+  }
+
+  return {
+    type: null,
+    error: `Invalid type: "${trimmed}". Expected: income, donation, maaser`,
+  };
+}
+
+// --- Note Sanitization ---
+
+/**
+ * Sanitize a note field: trim, enforce max length, strip control characters.
+ * @param {*} value - Raw note value
+ * @returns {string} Sanitized note (empty string if invalid)
+ */
+export function sanitizeNote(value) {
+  if (value === null || value === undefined) return '';
+  if (typeof value !== 'string') return String(value);
+
+  // Strip control characters (except newlines and tabs)
+  // eslint-disable-next-line no-control-regex
+  let sanitized = value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+  sanitized = sanitized.trim();
+
+  if (sanitized.length > NOTE_MAX_LENGTH) {
+    sanitized = sanitized.slice(0, NOTE_MAX_LENGTH);
+  }
+
+  return sanitized;
+}
+
+// --- Entry Validation ---
+
+/**
+ * Validate and normalize a single import entry.
+ * Coerces types, maps Hebrew values, validates all fields.
+ *
+ * @param {Object} raw - Raw entry object from parsed file
+ * @returns {{ valid: boolean, entry: Object|null, errors: string[] }}
+ */
+export function validateImportEntry(raw) {
+  const errors = [];
+
+  if (!raw || typeof raw !== 'object') {
+    return { valid: false, entry: null, errors: ['Entry must be an object'] };
+  }
+
+  // Sanitize for prototype pollution
+  const entry = sanitizeObject(raw);
+
+  // Type
+  const typeResult = mapTypeValue(entry.type);
+  if (typeResult.error) {
+    errors.push(typeResult.error);
+  }
+
+  // Amount
+  const amountResult = parseAmount(entry.amount);
+  if (amountResult.error) {
+    errors.push(amountResult.error);
+  }
+
+  // Date
+  const dateResult = parseDateValue(entry.date);
+  if (dateResult.error) {
+    errors.push(dateResult.error);
+  }
+
+  // Note (optional)
+  const note = sanitizeNote(entry.note);
+
+  if (errors.length > 0) {
+    return { valid: false, entry: null, errors };
+  }
+
+  return {
+    valid: true,
+    entry: {
+      type: typeResult.type,
+      amount: amountResult.amount,
+      date: dateResult.date,
+      note: note || undefined,
+    },
+    errors: [],
+  };
+}
+
+// --- JSON Parsing ---
+
+/**
+ * Read and parse a JSON file with schema validation.
+ *
+ * Expected JSON envelope:
+ * {
+ *   "version": 1,
+ *   "exportedAt": "...",
+ *   "entries": [...]
+ * }
+ *
+ * @param {File} file - File object to parse
+ * @returns {Promise<{ validEntries: Object[], invalidEntries: Object[], errors: string[], warnings: string[] }>}
+ */
+export async function parseJSONFile(file) {
+  const sizeCheck = validateFileSize(file);
+  const warnings = [];
+
+  if (!sizeCheck.valid) {
+    return { validEntries: [], invalidEntries: [], errors: [sizeCheck.error], warnings: [] };
+  }
+  if (sizeCheck.warning) {
+    warnings.push('File is large and may take a while to process');
+  }
+
+  let text;
+  try {
+    text = await file.text();
+  } catch {
+    return { validEntries: [], invalidEntries: [], errors: ['Failed to read file'], warnings };
+  }
+
+  // Strip BOM
+  text = stripBOM(text);
+
+  // Parse JSON
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return { validEntries: [], invalidEntries: [], errors: ['Invalid JSON format'], warnings };
+  }
+
+  // Prototype pollution protection
+  data = sanitizeObject(data);
+
+  // Validate envelope
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { validEntries: [], invalidEntries: [], errors: ['JSON must be an object with version and entries'], warnings };
+  }
+
+  if (data.version !== SCHEMA_VERSION) {
+    return {
+      validEntries: [],
+      invalidEntries: [],
+      errors: [`Unsupported schema version: ${data.version}. Expected: ${SCHEMA_VERSION}`],
+      warnings,
+    };
+  }
+
+  if (!Array.isArray(data.entries)) {
+    return { validEntries: [], invalidEntries: [], errors: ['JSON must contain an "entries" array'], warnings };
+  }
+
+  if (data.entries.length === 0) {
+    return { validEntries: [], invalidEntries: [], errors: ['No entries found in file'], warnings };
+  }
+
+  // Validate each entry
+  const validEntries = [];
+  const invalidEntries = [];
+  const entryErrors = [];
+
+  for (let i = 0; i < data.entries.length; i++) {
+    const result = validateImportEntry(data.entries[i]);
+    if (result.valid) {
+      validEntries.push(result.entry);
+    } else {
+      invalidEntries.push({ index: i, raw: data.entries[i], errors: result.errors });
+      entryErrors.push(`Entry ${i + 1}: ${result.errors.join(', ')}`);
+    }
+  }
+
+  return { validEntries, invalidEntries, errors: entryErrors, warnings };
+}
+
+// --- CSV Parsing ---
+
+/**
+ * Read and parse a CSV file with header mapping.
+ *
+ * Supports Hebrew and English column headers.
+ * Uses PapaParse for robust CSV parsing (BOM, CRLF, delimiters).
+ *
+ * @param {File} file - File object to parse
+ * @returns {Promise<{ validEntries: Object[], invalidEntries: Object[], errors: string[], warnings: string[] }>}
+ */
+export async function parseCSVFile(file) {
+  const sizeCheck = validateFileSize(file);
+  const warnings = [];
+
+  if (!sizeCheck.valid) {
+    return { validEntries: [], invalidEntries: [], errors: [sizeCheck.error], warnings: [] };
+  }
+  if (sizeCheck.warning) {
+    warnings.push('File is large and may take a while to process');
+  }
+
+  let text;
+  try {
+    text = await file.text();
+  } catch {
+    return { validEntries: [], invalidEntries: [], errors: ['Failed to read file'], warnings };
+  }
+
+  // Strip BOM
+  text = stripBOM(text);
+
+  // Dynamic import of PapaParse
+  let Papa;
+  try {
+    const module = await import('papaparse');
+    Papa = module.default || module;
+  } catch {
+    return { validEntries: [], invalidEntries: [], errors: ['Failed to load CSV parser'], warnings };
+  }
+
+  // Parse CSV
+  const parseResult = Papa.parse(text, {
+    header: true,
+    skipEmptyLines: true,
+    dynamicTyping: false, // We handle type coercion ourselves
+    delimiter: '', // Auto-detect (supports comma, semicolon, tab)
+  });
+
+  if (parseResult.errors && parseResult.errors.length > 0) {
+    const criticalErrors = parseResult.errors.filter(
+      (e) => e.type === 'Delimiter' || e.type === 'FieldMismatch'
+    );
+    if (criticalErrors.length > 0) {
+      return {
+        validEntries: [],
+        invalidEntries: [],
+        errors: criticalErrors.map((e) => `CSV parse error (row ${e.row + 1}): ${e.message}`),
+        warnings,
+      };
+    }
+    // Non-critical errors become warnings
+    for (const e of parseResult.errors) {
+      warnings.push(`CSV warning (row ${(e.row ?? 0) + 1}): ${e.message}`);
+    }
+  }
+
+  if (!parseResult.data || parseResult.data.length === 0) {
+    return { validEntries: [], invalidEntries: [], errors: ['No data rows found in CSV'], warnings };
+  }
+
+  // Map headers
+  const headers = parseResult.meta?.fields || [];
+  const { mapped, unmapped } = mapCSVHeaders(headers);
+
+  if (unmapped.length > 0) {
+    warnings.push(`Unmapped columns will be ignored: ${unmapped.join(', ')}`);
+  }
+
+  // Check we have minimum required mapped headers
+  const mappedValues = Object.values(mapped);
+  const hasType = mappedValues.includes('type');
+  const hasAmount = mappedValues.includes('amount');
+  const hasDate = mappedValues.includes('date');
+
+  if (!hasType || !hasAmount || !hasDate) {
+    const missing = [];
+    if (!hasType) missing.push('type');
+    if (!hasAmount) missing.push('amount');
+    if (!hasDate) missing.push('date');
+    return {
+      validEntries: [],
+      invalidEntries: [],
+      errors: [`Missing required columns: ${missing.join(', ')}`],
+      warnings,
+    };
+  }
+
+  // Convert rows to entries using header mapping
+  const validEntries = [];
+  const invalidEntries = [];
+  const entryErrors = [];
+
+  for (let i = 0; i < parseResult.data.length; i++) {
+    const row = parseResult.data[i];
+    const rawEntry = {};
+
+    for (const [originalHeader, fieldName] of Object.entries(mapped)) {
+      rawEntry[fieldName] = row[originalHeader];
+    }
+
+    const result = validateImportEntry(rawEntry);
+    if (result.valid) {
+      validEntries.push(result.entry);
+    } else {
+      invalidEntries.push({ index: i, raw: rawEntry, errors: result.errors });
+      entryErrors.push(`Row ${i + 1}: ${result.errors.join(', ')}`);
+    }
+  }
+
+  if (validEntries.length === 0 && invalidEntries.length === 0) {
+    return { validEntries: [], invalidEntries: [], errors: ['No data rows found in CSV'], warnings };
+  }
+
+  return { validEntries, invalidEntries, errors: entryErrors, warnings };
+}
+
+// ========================================================================
+// Import Engine — Batch Write & Conflict Resolution
+// ========================================================================
+
+/** Import mode: add entries alongside existing data */
+export const IMPORT_MODE_MERGE = 'merge';
+
+/** Import mode: clear all existing data, then add entries */
+export const IMPORT_MODE_REPLACE = 'replace';
+
+/** Batch size for IndexedDB writes */
+export const INDEXEDDB_BATCH_SIZE = 100;
+
+/**
+ * Yield control to the main thread to avoid UI freezing.
+ * Uses setTimeout(0) to let the browser process pending events.
+ * @returns {Promise<void>}
+ */
+function yieldToMainThread() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Prepare a validated entry for storage by assigning a new UUID,
+ * accountingMonth, and ensuring all required fields are present.
+ *
+ * @param {Object} entry - Validated entry from parseJSONFile/parseCSVFile
+ * @returns {Object} Entry ready for IndexedDB storage
+ */
+export function prepareEntryForStorage(entry) {
+  const id = crypto.randomUUID();
+  const accountingMonth = getAccountingMonthFromDate(entry.date);
+
+  return {
+    id,
+    type: entry.type,
+    amount: entry.amount,
+    date: entry.date,
+    note: entry.note || '',
+    accountingMonth,
+  };
+}
+
+/**
+ * Create an auto-backup of current entries as a JSON download.
+ * Called automatically before Replace mode to protect user data.
+ *
+ * @param {Array} entries - Current entries to back up
+ * @returns {{ success: boolean, entryCount: number, error: string|null }}
+ */
+export function createAutoBackup(entries) {
+  if (!entries || entries.length === 0) {
+    return { success: true, entryCount: 0, error: null };
+  }
+
+  try {
+    const json = exportToJSON(entries);
+    const filename = `backup-before-import-${generateFilename('json')}`;
+    downloadFile(json, filename, 'application/json');
+    return { success: true, entryCount: entries.length, error: null };
+  } catch (err) {
+    return { success: false, entryCount: 0, error: err.message };
+  }
+}
+
+/**
+ * Write entries to IndexedDB in batches, yielding to the main thread
+ * between each batch to keep the UI responsive.
+ *
+ * @param {Array} entries - Prepared entries (with id, accountingMonth, etc.)
+ * @param {Object} options
+ * @param {number} [options.batchSize=100] - Entries per batch
+ * @param {Function} [options.onProgress] - Callback: ({ current, total, phase })
+ * @param {number} [options.startOffset=0] - Starting offset for progress reporting
+ * @returns {Promise<{ written: number, failed: Array, errors: string[] }>}
+ */
+export async function batchWriteIndexedDB(entries, options = {}) {
+  const batchSize = options.batchSize || INDEXEDDB_BATCH_SIZE;
+  const onProgress = options.onProgress || null;
+  const startOffset = options.startOffset || 0;
+
+  let written = 0;
+  const failed = [];
+  const errors = [];
+
+  for (let i = 0; i < entries.length; i += batchSize) {
+    const batch = entries.slice(i, i + batchSize);
+
+    for (const entry of batch) {
+      try {
+        await addEntry(entry);
+        written++;
+      } catch (err) {
+        failed.push({ entry, error: err.message });
+        errors.push(`Failed to write entry ${entry.id}: ${err.message}`);
+      }
+    }
+
+    if (onProgress) {
+      onProgress({
+        current: startOffset + Math.min(i + batchSize, entries.length),
+        total: startOffset + entries.length,
+        phase: 'importing',
+      });
+    }
+
+    // Yield to main thread between batches (not after last batch)
+    if (i + batchSize < entries.length) {
+      await yieldToMainThread();
+    }
+  }
+
+  return { written, failed, errors };
+}
+
+/**
+ * Import entries in MERGE mode: generate new UUIDs and add alongside existing data.
+ *
+ * @param {Array} validatedEntries - Entries from parseJSONFile/parseCSVFile
+ * @param {Object} [options]
+ * @param {Function} [options.onProgress] - Progress callback
+ * @returns {Promise<{ success: boolean, imported: number, failed: Array, errors: string[] }>}
+ */
+export async function mergeEntries(validatedEntries, options = {}) {
+  const onProgress = options.onProgress || null;
+
+  if (!validatedEntries || validatedEntries.length === 0) {
+    return { success: false, imported: 0, failed: [], errors: ['No entries to import'] };
+  }
+
+  // Validation phase
+  if (onProgress) {
+    onProgress({ current: 0, total: validatedEntries.length, phase: 'validating' });
+  }
+
+  // Prepare entries with new UUIDs and accountingMonth
+  const prepared = validatedEntries.map(prepareEntryForStorage);
+
+  // Import phase
+  const result = await batchWriteIndexedDB(prepared, {
+    batchSize: INDEXEDDB_BATCH_SIZE,
+    onProgress,
+  });
+
+  // Complete phase
+  if (onProgress) {
+    onProgress({
+      current: validatedEntries.length,
+      total: validatedEntries.length,
+      phase: 'complete',
+    });
+  }
+
+  return {
+    success: result.errors.length === 0,
+    imported: result.written,
+    failed: result.failed,
+    errors: result.errors,
+  };
+}
+
+/**
+ * Import entries in REPLACE mode: auto-backup existing data, clear all entries,
+ * then batch-add the imported entries.
+ *
+ * @param {Array} validatedEntries - Entries from parseJSONFile/parseCSVFile
+ * @param {Object} [options]
+ * @param {Function} [options.onProgress] - Progress callback
+ * @param {boolean} [options.skipBackup=false] - Skip auto-backup (for testing)
+ * @returns {Promise<{ success: boolean, imported: number, backedUp: number, failed: Array, errors: string[] }>}
+ */
+export async function replaceAllEntries(validatedEntries, options = {}) {
+  const onProgress = options.onProgress || null;
+  const skipBackup = options.skipBackup || false;
+
+  if (!validatedEntries || validatedEntries.length === 0) {
+    return { success: false, imported: 0, backedUp: 0, failed: [], errors: ['No entries to import'] };
+  }
+
+  const errors = [];
+  let backedUp = 0;
+
+  // Validation phase
+  if (onProgress) {
+    onProgress({ current: 0, total: validatedEntries.length, phase: 'validating' });
+  }
+
+  // Backup phase
+  if (!skipBackup) {
+    if (onProgress) {
+      onProgress({ current: 0, total: validatedEntries.length, phase: 'backing-up' });
+    }
+
+    try {
+      const existingEntries = await getAllEntries();
+      if (existingEntries.length > 0) {
+        const backupResult = createAutoBackup(existingEntries);
+        if (!backupResult.success) {
+          return {
+            success: false,
+            imported: 0,
+            backedUp: 0,
+            failed: [],
+            errors: [`Auto-backup failed: ${backupResult.error}. Import aborted for safety.`],
+          };
+        }
+        backedUp = backupResult.entryCount;
+      }
+    } catch (err) {
+      return {
+        success: false,
+        imported: 0,
+        backedUp: 0,
+        failed: [],
+        errors: [`Failed to read existing entries for backup: ${err.message}. Import aborted.`],
+      };
+    }
+  }
+
+  // Clearing phase
+  if (onProgress) {
+    onProgress({ current: 0, total: validatedEntries.length, phase: 'clearing' });
+  }
+
+  try {
+    await clearAllEntries();
+  } catch (err) {
+    return {
+      success: false,
+      imported: 0,
+      backedUp,
+      failed: [],
+      errors: [`Failed to clear existing entries: ${err.message}. Import aborted.`],
+    };
+  }
+
+  // Prepare entries with new UUIDs
+  const prepared = validatedEntries.map(prepareEntryForStorage);
+
+  // Import phase
+  const writeResult = await batchWriteIndexedDB(prepared, {
+    batchSize: INDEXEDDB_BATCH_SIZE,
+    onProgress,
+  });
+
+  // Complete phase
+  if (onProgress) {
+    onProgress({
+      current: validatedEntries.length,
+      total: validatedEntries.length,
+      phase: 'complete',
+    });
+  }
+
+  return {
+    success: writeResult.errors.length === 0,
+    imported: writeResult.written,
+    backedUp,
+    failed: writeResult.failed,
+    errors: [...errors, ...writeResult.errors],
+  };
+}
+
+/**
+ * Main import orchestrator. Delegates to merge or replace based on mode.
+ *
+ * @param {Array} validatedEntries - Entries from parseJSONFile/parseCSVFile
+ * @param {string} mode - Import mode: 'merge' or 'replace'
+ * @param {Object} [options]
+ * @param {Function} [options.onProgress] - Progress callback: ({ current, total, phase })
+ * @param {boolean} [options.skipBackup=false] - Skip auto-backup in replace mode
+ * @returns {Promise<{ success: boolean, mode: string, imported: number, backedUp: number, failed: Array, errors: string[] }>}
+ */
+export async function importEntries(validatedEntries, mode = IMPORT_MODE_MERGE, options = {}) {
+  if (mode !== IMPORT_MODE_MERGE && mode !== IMPORT_MODE_REPLACE) {
+    return {
+      success: false,
+      mode,
+      imported: 0,
+      backedUp: 0,
+      failed: [],
+      errors: [`Invalid import mode: "${mode}". Use "${IMPORT_MODE_MERGE}" or "${IMPORT_MODE_REPLACE}".`],
+    };
+  }
+
+  if (!validatedEntries || validatedEntries.length === 0) {
+    return {
+      success: false,
+      mode,
+      imported: 0,
+      backedUp: 0,
+      failed: [],
+      errors: ['No entries to import'],
+    };
+  }
+
+  if (mode === IMPORT_MODE_REPLACE) {
+    const result = await replaceAllEntries(validatedEntries, options);
+    return { ...result, mode };
+  }
+
+  // Default: MERGE mode
+  const result = await mergeEntries(validatedEntries, options);
+  return { ...result, mode, backedUp: 0 };
+}


### PR DESCRIPTION
## Summary

Promotes Epic #41 (Import/Export JSON & CSV) from `develop` to `main` for production release.

### Sub-issues included
- **#112** Export Service (JSON + CSV)
- **#113** Import Service — Parse & Validate
- **#114** Import Engine — Batch Write & Conflict Resolution
- **#115** Import/Export translation keys (bilingual)
- **#116** Import/Export UI Components
- **#117** Integration tests and edge cases

### What changed
- New `exportService.js` — export entries as JSON or CSV (via papaparse)
- New `importService.js` — parse, validate, and import entries from JSON/CSV files
- New `ImportExportSection` component — Settings page UI for import/export
- New `ImportPreviewDialog` component — preview and conflict resolution before import
- New `useImportExport` hook — orchestrates import/export state and operations
- Bilingual translations (Hebrew/English) for all import/export UI strings
- 836-line integration test suite + comprehensive unit tests
- Regression test plan updated with import/export test cases

### Stats
- **18 files changed**, 5,949 insertions
- **1,834 tests passing**, 1 skipped, 0 failures
- **Lint clean** — 0 errors, 0 warnings

Closes #41

## Checklist
- [x] All sub-issues merged to epic branch
- [x] Epic branch merged to develop (no conflicts)
- [x] All 1,834 tests passing
- [x] Lint clean (0 errors, 0 warnings)
- [x] Merge commit preserves sub-issue history

## Test plan
- [ ] CI passes on this PR
- [ ] Verify export JSON produces valid file with all entries
- [ ] Verify export CSV produces valid file parseable by Excel
- [ ] Verify import JSON with valid file adds entries correctly
- [ ] Verify import CSV with valid file adds entries correctly
- [ ] Verify conflict resolution UI works (skip/overwrite/keep both)
- [ ] Verify bilingual UI (Hebrew RTL / English LTR)
- [ ] Verify import/export section appears in Settings page
- [ ] Run regression suite on production after merge