### PR TITLE
#129 Fix import cache invalidation — entries appear after import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,6 +274,13 @@ function MainApp({ theme, cacheRtl }) {
     setCurrentTab(0);
   }, []);
 
+  // Navigate to a specific tab from within Settings (e.g., after import success)
+  const handleNavigateToTab = useCallback((tabIndex) => {
+    setShowSettings(false);
+    setEditEntry(null);
+    setCurrentTab(tabIndex);
+  }, []);
+
   // Show IndexedDB unavailable screen
   if (!indexedDBSupported) {
     return <IndexedDBUnavailable t={t} />;
@@ -306,7 +313,7 @@ function MainApp({ theme, cacheRtl }) {
     }
 
     if (showSettings) {
-      return <SettingsPage onBack={handleCloseSettings} />;
+      return <SettingsPage onBack={handleCloseSettings} onNavigateToTab={handleNavigateToTab} />;
     }
 
     switch (currentTab) {

--- a/src/components/ImportExportSection.jsx
+++ b/src/components/ImportExportSection.jsx
@@ -25,7 +25,7 @@ import { useEntries } from '../hooks/useEntries';
 import { useExportJSON, useExportCSV, useImport } from '../hooks/useImportExport';
 import ImportPreviewDialog from './ImportPreviewDialog';
 
-function ImportExportSection() {
+function ImportExportSection({ onNavigateToTab }) {
   const { t } = useLanguage();
   const { data: entries } = useEntries();
   const exportJSON = useExportJSON();
@@ -164,6 +164,7 @@ function ImportExportSection() {
         open={importHook.state !== 'idle'}
         importHook={importHook}
         onClose={handleDialogClose}
+        onNavigateToTab={onNavigateToTab}
       />
 
       {/* Snackbar for export feedback */}

--- a/src/components/ImportPreviewDialog.jsx
+++ b/src/components/ImportPreviewDialog.jsx
@@ -70,7 +70,7 @@ function formatFileSize(bytes) {
   return `${mb.toFixed(1)} MB`;
 }
 
-function ImportPreviewDialog({ open, importHook, onClose }) {
+function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
   const { t, direction } = useLanguage();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -134,6 +134,18 @@ function ImportPreviewDialog({ open, importHook, onClose }) {
   const handleToggleInvalid = useCallback(() => {
     setShowInvalid((prev) => !prev);
   }, []);
+
+  const handleViewEntries = useCallback(() => {
+    // Reset dialog state, then navigate to History tab (tab 3)
+    setImportMode(IMPORT_MODE_MERGE);
+    setReplaceConfirmed(false);
+    setShowInvalid(false);
+    reset();
+    onClose();
+    if (onNavigateToTab) {
+      onNavigateToTab(3);
+    }
+  }, [reset, onClose, onNavigateToTab]);
 
   const canImport = state === ImportState.PREVIEW
     && parseResult?.validEntries?.length > 0
@@ -351,18 +363,36 @@ function ImportPreviewDialog({ open, importHook, onClose }) {
   const renderSuccess = () => (
     <>
       <DialogContent>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
+        <Box
+          sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}
+          role="status"
+          aria-live="polite"
+        >
           <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 2 }} />
           <Typography variant="h6" gutterBottom>
             {(st.importSuccess || 'Successfully imported {count} entries')
               .replace('{count}', String(importResult?.imported || 0))}
           </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {st.importSuccessHint || 'Your entries have been imported successfully'}
+          </Typography>
         </Box>
       </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={handleClose} variant="contained" sx={{ textTransform: 'none' }} size="large">
-          {st.cancel || t.cancel || 'Close'}
+      <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Button onClick={handleClose} sx={{ textTransform: 'none' }} size="large">
+          {st.done || 'Done'}
         </Button>
+        {onNavigateToTab && (
+          <Button
+            onClick={handleViewEntries}
+            variant="contained"
+            sx={{ textTransform: 'none' }}
+            size="large"
+            autoFocus
+          >
+            {st.viewEntries || 'View Entries'}
+          </Button>
+        )}
       </DialogActions>
     </>
   );

--- a/src/components/ImportPreviewDialog.test.jsx
+++ b/src/components/ImportPreviewDialog.test.jsx
@@ -61,6 +61,9 @@ const defaultTranslations = {
       importTitle: 'Import mode',
       cancel: 'Cancel',
       import: 'Import',
+      done: 'Done',
+      viewEntries: 'View Entries',
+      importSuccessHint: 'Your entries have been imported successfully',
     },
   },
   loading: 'Loading...',
@@ -356,7 +359,7 @@ describe('ImportPreviewDialog', () => {
         importResult: { imported: 10 },
       });
 
-      expect(screen.getByRole('button', { name: /Cancel|Close/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Done/i })).toBeInTheDocument();
     });
   });
 

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -84,7 +84,7 @@ function getTodayString() {
   return `${year}-${month}-${day}`;
 }
 
-export default function SettingsPage({ onBack }) {
+export default function SettingsPage({ onBack, onNavigateToTab }) {
   const { t, language, direction } = useLanguage();
   const {
     settings,
@@ -450,7 +450,7 @@ export default function SettingsPage({ onBack }) {
       </Paper>
 
       {/* Section 4: Data Management (Import/Export) */}
-      <ImportExportSection />
+      <ImportExportSection onNavigateToTab={onNavigateToTab} />
 
       {/* Section 5: About */}
       <Paper sx={{ p: 2 }}>

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -414,6 +414,10 @@ const translations = {
         iosSaveHint: 'הקש על סמל השיתוף כדי לשמור את הקובץ',
         cancel: 'ביטול',
         import: 'ייבוא',
+        // Success dialog actions
+        done: 'סיום',
+        viewEntries: 'צפה ברשומות',
+        importSuccessHint: 'הרשומות שלך יובאו בהצלחה',
       },
     },
   },
@@ -817,6 +821,10 @@ const translations = {
         iosSaveHint: 'Tap the share icon to save the file',
         cancel: 'Cancel',
         import: 'Import',
+        // Success dialog actions
+        done: 'Done',
+        viewEntries: 'View Entries',
+        importSuccessHint: 'Your entries have been imported successfully',
       },
     },
   },

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -322,6 +322,9 @@ describe('Settings Translation Keys', () => {
       'iosSaveHint',
       'cancel',
       'import',
+      'done',
+      'viewEntries',
+      'importSuccessHint',
     ];
 
     it('should have importExport as a nested object in both languages', () => {

--- a/src/hooks/useImportExport.js
+++ b/src/hooks/useImportExport.js
@@ -190,8 +190,10 @@ export function useImport() {
       if (result.success) {
         setImportResult(result);
         setState(ImportState.SUCCESS);
-        // Invalidate entries cache so UI refreshes
-        await queryClient.invalidateQueries({ queryKey: queryKeys.all });
+        // Remove cached entries entirely so Dashboard/History fetch fresh data on mount.
+        // invalidateQueries only marks stale — unmounted queries won't refetch,
+        // and 5-min staleTime may serve pre-import data on remount.
+        queryClient.removeQueries({ queryKey: queryKeys.all });
       } else {
         setState(ImportState.ERROR);
         setError(result.errors?.[0] || 'Import failed');


### PR DESCRIPTION
## Summary
Fix React Query cache invalidation after import operations. Entries now appear immediately in Dashboard/History after import.

**Root cause:** Import writes directly to IndexedDB bypassing React Query mutations. `invalidateQueries` only marks queries stale but doesn't force refetch of unmounted Dashboard/History components.

**Fix:** Replace `invalidateQueries` with `removeQueries` (deletes cached data entirely), add navigation from success dialog to History view, improve success dialog UX with proper labels.

Closes #129

## Changes
- `useImportExport.js`: `removeQueries` instead of `invalidateQueries`
- `ImportPreviewDialog.jsx`: Success dialog with "View Entries" + "Done" buttons, WCAG status role
- `ImportExportSection.jsx` + `SettingsPage.jsx` + `App.jsx`: Thread `onNavigateToTab` callback
- `LanguageProvider.jsx`: 3 new bilingual translation keys
- Tests updated to match new translations

## Test Results
- 1834 tests passing, 0 failures
- Lint: clean

## Checklist
- [x] Tests pass
- [x] Lint clean
- [ ] Manual test verified
- [ ] Hebrew RTL tested
- [ ] English LTR tested