### PR TITLE
#131 #132 Fix export — add maaser column, normalize dates

### DIFF
--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -172,6 +172,31 @@ describe('exportToJSON', () => {
     expect(parsed.entries[0].id).toBe('e1');
     expect(parsed.entries[0]).not.toHaveProperty('note');
   });
+
+  it('should normalize ISO datetime to YYYY-MM-DD (#131)', () => {
+    const entries = [makeEntry({ date: '2026-03-01T00:00:00.000Z' })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].date).toBe('2026-03-01');
+  });
+
+  it('should keep YYYY-MM-DD dates unchanged (#131)', () => {
+    const entries = [makeEntry({ date: '2026-06-15' })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].date).toBe('2026-06-15');
+  });
+
+  it('should not mutate original entry date during normalization (#131)', () => {
+    const original = makeEntry({ date: '2026-03-01T00:00:00.000Z' });
+    const entries = [original];
+    exportToJSON(entries);
+    expect(original.date).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('should include maaser field in JSON export (#132)', () => {
+    const entries = [makeEntry({ maaser: 500 })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].maaser).toBe(500);
+  });
 });
 
 // --- exportToCSV ---
@@ -191,8 +216,24 @@ describe('exportToCSV', () => {
     expect(firstLine).toContain('type');
     expect(firstLine).toContain('date');
     expect(firstLine).toContain('amount');
+    expect(firstLine).toContain('maaser');
     expect(firstLine).toContain('note');
     expect(firstLine).toContain('accountingMonth');
+  });
+
+  it('should include maaser column with correct values (#132)', async () => {
+    const entries = [makeEntry({ maaser: 500 })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('maaser');
+    expect(result).toContain('500');
+  });
+
+  it('should handle entries without maaser field in CSV (#132)', async () => {
+    const entries = [makeEntry({ type: 'donation' })];
+    const result = await exportToCSV(entries);
+    // Header should still be present even if entry has no maaser value
+    const firstLine = result.replace('\uFEFF', '').split('\n')[0];
+    expect(firstLine).toContain('maaser');
   });
 
   it('should include entry data in CSV output', async () => {
@@ -273,6 +314,20 @@ describe('exportToCSV', () => {
     const entries = [makeEntry({ note: 'משכורת חודשית' })];
     const result = await exportToCSV(entries);
     expect(result).toContain('משכורת חודשית');
+  });
+
+  it('should normalize ISO datetime to YYYY-MM-DD in CSV (#131)', async () => {
+    const entries = [makeEntry({ date: '2026-03-01T00:00:00.000Z' })];
+    const result = await exportToCSV(entries);
+    // Should contain the normalized date, not the full ISO string
+    expect(result).toContain('2026-03-01');
+    expect(result).not.toContain('T00:00:00');
+  });
+
+  it('should keep YYYY-MM-DD dates unchanged in CSV (#131)', async () => {
+    const entries = [makeEntry({ date: '2026-06-15' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('2026-06-15');
   });
 });
 

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -19,7 +19,23 @@ const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@'];
 const UTF8_BOM = '\uFEFF';
 
 /** CSV column headers (English) */
-const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'note', 'accountingMonth'];
+const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth'];
+
+/**
+ * Normalize a date value to YYYY-MM-DD format.
+ * Handles full ISO strings (e.g., "2026-03-01T00:00:00.000Z") and
+ * plain date strings (e.g., "2026-03-01").
+ * @param {string} dateValue - Date string to normalize
+ * @returns {string} Date in YYYY-MM-DD format, or original value if not parseable
+ */
+function normalizeDateToYMD(dateValue) {
+  if (!dateValue || typeof dateValue !== 'string') return dateValue;
+  try {
+    return new Date(dateValue).toISOString().split('T')[0];
+  } catch {
+    return dateValue;
+  }
+}
 
 /**
  * Strip internal/server-side fields from an entry for export.
@@ -30,6 +46,20 @@ function stripInternalFields(entry) {
   const cleaned = { ...entry };
   for (const field of INTERNAL_FIELDS) {
     delete cleaned[field];
+  }
+  return cleaned;
+}
+
+/**
+ * Prepare an entry for export by stripping internal fields
+ * and normalizing the date to YYYY-MM-DD format.
+ * @param {Object} entry - Entry object to prepare
+ * @returns {Object} Cleaned entry with normalized date
+ */
+function prepareEntryForExport(entry) {
+  const cleaned = stripInternalFields(entry);
+  if (cleaned.date) {
+    cleaned.date = normalizeDateToYMD(cleaned.date);
   }
   return cleaned;
 }
@@ -88,7 +118,7 @@ export function exportToJSON(entries) {
     throw new Error('No entries to export');
   }
 
-  const cleanedEntries = entries.map(stripInternalFields);
+  const cleanedEntries = entries.map(prepareEntryForExport);
 
   const envelope = {
     version: EXPORT_SCHEMA_VERSION,
@@ -117,7 +147,7 @@ export async function exportToCSV(entries) {
 
   const Papa = await import('papaparse');
 
-  const cleanedEntries = entries.map(stripInternalFields);
+  const cleanedEntries = entries.map(prepareEntryForExport);
   const sanitizedEntries = cleanedEntries.map(sanitizeEntryForCsv);
 
   const csv = Papa.default.unparse(sanitizedEntries, {


### PR DESCRIPTION
## Summary
Two export fixes in one PR:
- **#132:** Add missing `maaser` column to CSV export headers
- **#131:** Normalize dates to YYYY-MM-DD in both JSON and CSV exports (remove midnight UTC timestamps)

Closes #131
Closes #132

## Changes
- `exportService.js`: Added `maaser` to CSV_HEADERS, added `normalizeDateToYMD()` + `prepareEntryForExport()` helpers
- `exportService.test.js`: 9 new test cases covering both fixes

## Test Results
- 1842 tests passing, 0 failures
- Lint: clean

## Checklist
- [x] Tests pass
- [x] Lint clean
- [ ] Manual test verified
- [ ] Hebrew RTL tested
- [ ] English LTR tested