### PR TITLE
#133 Add GDPR data management section to Settings page

### DIFF
--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -1,12 +1,13 @@
 /**
  * SettingsPage Component
  *
- * Full settings page with five sections:
+ * Full settings page with six sections:
  * 1. General (language, currency)
  * 2. Ma'aser Calculation (percentage management)
  * 3. Appearance (theme toggle)
  * 4. Data Management (import/export)
- * 5. About (version, links)
+ * 5. Cloud Data & Privacy (GDPR: export/delete data)
+ * 6. About (version, links)
  *
  * All settings auto-save immediately except ma'aser percentage
  * which requires confirmation via dialog.
@@ -14,12 +15,15 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import {
+  Alert,
   Box,
   Typography,
   IconButton,
   Select,
   MenuItem,
   FormControl,
+  FormControlLabel,
+  Checkbox,
   InputLabel,
   TextField,
   Slider,
@@ -41,6 +45,7 @@ import {
   ListItem,
   ListItemText,
   CircularProgress,
+  Snackbar,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -48,9 +53,18 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
+import SecurityIcon from '@mui/icons-material/Security';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useLanguage } from '../contexts/useLanguage';
 import { useSettings } from '../hooks/useSettings';
+import { useAuth } from '../hooks/useAuth';
+import { useQueryClient } from '@tanstack/react-query';
+import { clearAllEntries } from '../services/db';
+import { queryKeys } from '../hooks/useEntries';
 import ImportExportSection from './ImportExportSection';
+import DataManagementDialog from './DataManagementDialog';
 
 const APP_VERSION = '1.2.0';
 const GITHUB_URL = 'https://github.com/DubiWork/maaser-tracker';
@@ -95,14 +109,27 @@ export default function SettingsPage({ onBack }) {
     updateMaaserPercentage,
     getCurrentMaaserPercentage,
   } = useSettings();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
 
   const st = t.settings;
+  const cdp = st.cloudDataPrivacy || {};
 
   // Ma'aser percentage form state
   const [newPercentage, setNewPercentage] = useState(10);
   const [effectiveDate, setEffectiveDate] = useState(getTodayString);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [percentageError, setPercentageError] = useState('');
+
+  // GDPR Cloud Data & Privacy state
+  const [gdprDialogOpen, setGdprDialogOpen] = useState(false);
+  const [gdprDialogAction, setGdprDialogAction] = useState(null);
+
+  // Local data deletion state
+  const [deleteLocalDialogOpen, setDeleteLocalDialogOpen] = useState(false);
+  const [deleteLocalConfirmed, setDeleteLocalConfirmed] = useState(false);
+  const [isDeletingLocal, setIsDeletingLocal] = useState(false);
+  const [deleteLocalSnackbar, setDeleteLocalSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
   const currentPercentage = useMemo(
     () => getCurrentMaaserPercentage(),
@@ -198,6 +225,63 @@ export default function SettingsPage({ onBack }) {
 
   const handlePrivacyClick = useCallback(() => {
     window.location.hash = '#/privacy';
+  }, []);
+
+  // --- GDPR Cloud Data & Privacy Handlers ---
+
+  const handleGdprExportClick = useCallback(() => {
+    setGdprDialogAction('export');
+    setGdprDialogOpen(true);
+  }, []);
+
+  const handleGdprDeleteClick = useCallback(() => {
+    setGdprDialogAction('delete');
+    setGdprDialogOpen(true);
+  }, []);
+
+  const handleGdprDialogClose = useCallback(() => {
+    setGdprDialogOpen(false);
+    setGdprDialogAction(null);
+  }, []);
+
+  // --- Local Data Deletion Handlers ---
+
+  const handleDeleteLocalClick = useCallback(() => {
+    setDeleteLocalDialogOpen(true);
+    setDeleteLocalConfirmed(false);
+  }, []);
+
+  const handleDeleteLocalCancel = useCallback(() => {
+    setDeleteLocalDialogOpen(false);
+    setDeleteLocalConfirmed(false);
+  }, []);
+
+  const handleDeleteLocalConfirm = useCallback(async () => {
+    setIsDeletingLocal(true);
+    try {
+      await clearAllEntries();
+      queryClient.removeQueries({ queryKey: queryKeys.all });
+      await queryClient.refetchQueries({ queryKey: queryKeys.all, type: 'all' });
+      setDeleteLocalDialogOpen(false);
+      setDeleteLocalConfirmed(false);
+      setDeleteLocalSnackbar({
+        open: true,
+        message: cdp.deleteLocalSuccess || 'All local data has been deleted successfully',
+        severity: 'success',
+      });
+    } catch {
+      setDeleteLocalSnackbar({
+        open: true,
+        message: st.errorSavingSettings || 'An error occurred',
+        severity: 'error',
+      });
+    } finally {
+      setIsDeletingLocal(false);
+    }
+  }, [cdp.deleteLocalSuccess, st.errorSavingSettings, queryClient]);
+
+  const handleDeleteLocalSnackbarClose = useCallback(() => {
+    setDeleteLocalSnackbar((prev) => ({ ...prev, open: false }));
   }, []);
 
   // Currency label helper
@@ -452,7 +536,83 @@ export default function SettingsPage({ onBack }) {
       {/* Section 4: Data Management (Import/Export) */}
       <ImportExportSection />
 
-      {/* Section 5: About */}
+      {/* Section 5: Cloud Data & Privacy (GDPR) */}
+      <Paper sx={{ p: 2, mb: 2 }} data-testid="cloud-data-privacy-section">
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <SecurityIcon color="action" fontSize="small" />
+          <Typography variant="h6" component="h2" sx={{ fontWeight: 500 }}>
+            {cdp.title || 'Cloud Data & Privacy'}
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {cdp.description || 'Export or delete your cloud data'}
+        </Typography>
+
+        {user ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Button
+              variant="outlined"
+              startIcon={<CloudDownloadIcon />}
+              onClick={handleGdprExportClick}
+              sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5 }}
+              aria-label={cdp.exportMyData || 'Export My Data'}
+            >
+              <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {cdp.exportMyData || 'Export My Data'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {cdp.exportDescription || 'Download all your cloud data as a JSON file'}
+                </Typography>
+              </Box>
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteForeverIcon />}
+              onClick={handleGdprDeleteClick}
+              sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5 }}
+              aria-label={cdp.deleteAllData || 'Delete All Data'}
+            >
+              <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {cdp.deleteAllData || 'Delete All Data'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {cdp.deleteDescription || 'Permanently delete all your cloud data'}
+                </Typography>
+              </Box>
+            </Button>
+          </Box>
+        ) : (
+          <Alert severity="info" sx={{ mt: 1 }}>
+            {cdp.signInToManage || 'Sign in to manage your cloud data'}
+          </Alert>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Local data deletion - available to all users */}
+        <Button
+          variant="outlined"
+          color="error"
+          startIcon={<DeleteOutlineIcon />}
+          onClick={handleDeleteLocalClick}
+          sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5, width: '100%' }}
+          aria-label={cdp.deleteLocalData || 'Delete Local Data'}
+        >
+          <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {cdp.deleteLocalData || 'Delete Local Data'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {cdp.deleteLocalDescription || 'Delete all entries stored on this device'}
+            </Typography>
+          </Box>
+        </Button>
+      </Paper>
+
+      {/* Section 6: About */}
       <Paper sx={{ p: 2 }}>
         <Typography variant="h6" component="h2" sx={{ fontWeight: 500, mb: 2 }}>
           {st.about}
@@ -512,6 +672,78 @@ export default function SettingsPage({ onBack }) {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* GDPR Data Management Dialog (cloud export/delete) */}
+      <DataManagementDialog
+        open={gdprDialogOpen}
+        onClose={handleGdprDialogClose}
+        initialAction={gdprDialogAction}
+      />
+
+      {/* Local data deletion confirmation dialog */}
+      <Dialog
+        open={deleteLocalDialogOpen}
+        onClose={isDeletingLocal ? undefined : handleDeleteLocalCancel}
+        dir={direction}
+        aria-labelledby="delete-local-dialog-title"
+        disableEscapeKeyDown={isDeletingLocal}
+      >
+        <DialogTitle id="delete-local-dialog-title">
+          {cdp.deleteLocalData || 'Delete Local Data'}
+        </DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {cdp.deleteLocalWarning || 'This will permanently delete all entries stored on this device. This action cannot be undone.'}
+          </Alert>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={deleteLocalConfirmed}
+                onChange={(e) => setDeleteLocalConfirmed(e.target.checked)}
+                color="error"
+                disabled={isDeletingLocal}
+              />
+            }
+            label={cdp.deleteLocalConfirmCheckbox || 'I understand all my local data will be permanently deleted'}
+          />
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'space-between', px: 3, pb: 2 }}>
+          <Button
+            onClick={handleDeleteLocalCancel}
+            disabled={isDeletingLocal}
+            sx={{ textTransform: 'none' }}
+          >
+            {t.cancel}
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            startIcon={isDeletingLocal ? <CircularProgress size={16} color="inherit" /> : <DeleteForeverIcon />}
+            disabled={!deleteLocalConfirmed || isDeletingLocal}
+            onClick={handleDeleteLocalConfirm}
+            sx={{ textTransform: 'none' }}
+          >
+            {cdp.deleteLocalButton || 'Delete Local Data'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Snackbar for local deletion feedback */}
+      <Snackbar
+        open={deleteLocalSnackbar.open}
+        autoHideDuration={4000}
+        onClose={handleDeleteLocalSnackbarClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleDeleteLocalSnackbarClose}
+          severity={deleteLocalSnackbar.severity}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {deleteLocalSnackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/components/SettingsPage.test.jsx
+++ b/src/components/SettingsPage.test.jsx
@@ -1,9 +1,9 @@
 /**
  * Tests for SettingsPage and SettingsButton components
  *
- * Covers all five sections (General, Ma'aser Calculation, Appearance,
- * Data Management, About), navigation, auto-save pattern, confirmation dialog,
- * percentage history, bilingual support, and accessibility.
+ * Covers all six sections (General, Ma'aser Calculation, Appearance,
+ * Data Management, Cloud Data & Privacy, About), navigation, auto-save pattern,
+ * confirmation dialog, percentage history, bilingual support, and accessibility.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,6 +18,35 @@ import SettingsButton from './SettingsButton';
 vi.mock('./ImportExportSection', () => ({
   default: () => <div data-testid="import-export-section"><h2>Data Management</h2></div>,
 }));
+
+// Mock DataManagementDialog since it has its own test suite
+vi.mock('./DataManagementDialog', () => ({
+  default: ({ open }) => open ? <div data-testid="data-management-dialog">DataManagementDialog</div> : null,
+}));
+
+// Mock useAuth hook
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: null })),
+}));
+
+// Mock db service
+vi.mock('../services/db', () => ({
+  clearAllEntries: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock useEntries queryKeys
+vi.mock('../hooks/useEntries', () => ({
+  queryKeys: {
+    all: ['entries'],
+    lists: () => ['entries', 'list'],
+    list: (filters) => ['entries', 'list', filters],
+    details: () => ['entries', 'detail'],
+    detail: (id) => ['entries', 'detail', id],
+    migrationStatus: (userId) => ['migration', 'status', userId],
+  },
+}));
+
+import { useAuth } from '../hooks/useAuth';
 
 // Mock IndexedDB settings service
 vi.mock('../services/settingsDb', () => ({
@@ -594,7 +623,7 @@ describe('SettingsPage', () => {
 
       // h2: Section headings
       const h2s = screen.getAllByRole('heading', { level: 2 });
-      expect(h2s.length).toBe(5);
+      expect(h2s.length).toBe(6);
     });
 
     it('should have aria-label on back button', async () => {

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -175,30 +175,26 @@ function UserProfile() {
           />
         </MenuItem>
 
-        {/* GDPR data management - only when cloud sync completed */}
-        {migrationStatus === 'completed' && (
-          <>
-            <Divider />
-            <MenuItem onClick={handleExportClick}>
-              <ListItemIcon>
-                <FileUploadIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText
-                primary={t.dataManagement?.exportMyData || 'Export my data'}
-                primaryTypographyProps={{ variant: 'body2' }}
-              />
-            </MenuItem>
-            <MenuItem onClick={handleDeleteClick}>
-              <ListItemIcon>
-                <DeleteForeverIcon fontSize="small" color="error" />
-              </ListItemIcon>
-              <ListItemText
-                primary={t.dataManagement?.deleteCloudData || 'Delete cloud data'}
-                primaryTypographyProps={{ variant: 'body2', color: 'error.main' }}
-              />
-            </MenuItem>
-          </>
-        )}
+        {/* GDPR data management - available to all authenticated users */}
+        <Divider />
+        <MenuItem onClick={handleExportClick}>
+          <ListItemIcon>
+            <FileUploadIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText
+            primary={t.dataManagement?.exportMyData || 'Export my data'}
+            primaryTypographyProps={{ variant: 'body2' }}
+          />
+        </MenuItem>
+        <MenuItem onClick={handleDeleteClick}>
+          <ListItemIcon>
+            <DeleteForeverIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText
+            primary={t.dataManagement?.deleteCloudData || 'Delete cloud data'}
+            primaryTypographyProps={{ variant: 'body2', color: 'error.main' }}
+          />
+        </MenuItem>
 
         <Divider />
 

--- a/src/components/UserProfile.test.jsx
+++ b/src/components/UserProfile.test.jsx
@@ -436,31 +436,31 @@ describe('UserProfile', () => {
       expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is idle', () => {
+    it('should show GDPR menu items when migrationStatus is idle (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'idle' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is in-progress', () => {
+    it('should show GDPR menu items when migrationStatus is in-progress (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'in-progress' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is failed', () => {
+    it('should show GDPR menu items when migrationStatus is failed (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'failed' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
     it('should have FileUploadIcon SVG on export menu item', () => {

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -352,6 +352,23 @@ const translations = {
       deleteAccountConfirm: 'האם אתה בטוח שברצונך למחוק את החשבון? פעולה זו לא ניתנת לביטול.',
       actionCannotBeUndone: 'פעולה זו לא ניתנת לביטול',
 
+      // Cloud Data & Privacy section (GDPR)
+      cloudDataPrivacy: {
+        title: 'נתוני ענן ופרטיות',
+        description: 'ייצוא או מחיקת נתוני הענן שלך',
+        exportMyData: 'ייצוא הנתונים שלי',
+        exportDescription: 'הורד את כל נתוני הענן שלך כקובץ JSON',
+        deleteAllData: 'מחיקת כל הנתונים',
+        deleteDescription: 'מחק לצמיתות את כל נתוני הענן שלך',
+        signInToManage: 'התחבר/י כדי לנהל את נתוני הענן שלך',
+        deleteLocalData: 'מחיקת נתונים מקומיים',
+        deleteLocalDescription: 'מחק את כל הרשומות השמורות במכשיר זה',
+        deleteLocalWarning: 'פעולה זו תמחק לצמיתות את כל הרשומות השמורות במכשיר זה. פעולה זו לא ניתנת לביטול.',
+        deleteLocalConfirmCheckbox: 'אני מבין/ה שכל הנתונים המקומיים שלי יימחקו לצמיתות',
+        deleteLocalSuccess: 'כל הנתונים המקומיים נמחקו בהצלחה',
+        deleteLocalButton: 'מחק נתונים מקומיים',
+      },
+
       // About section
       about: 'אודות',
       version: 'גרסה',
@@ -754,6 +771,23 @@ const translations = {
       clearDataConfirm: 'Are you sure you want to clear all data?',
       deleteAccountConfirm: 'Are you sure you want to delete your account? This action cannot be undone.',
       actionCannotBeUndone: 'This action cannot be undone',
+
+      // Cloud Data & Privacy section (GDPR)
+      cloudDataPrivacy: {
+        title: 'Cloud Data & Privacy',
+        description: 'Export or delete your cloud data',
+        exportMyData: 'Export My Data',
+        exportDescription: 'Download all your cloud data as a JSON file',
+        deleteAllData: 'Delete All Data',
+        deleteDescription: 'Permanently delete all your cloud data',
+        signInToManage: 'Sign in to manage your cloud data',
+        deleteLocalData: 'Delete Local Data',
+        deleteLocalDescription: 'Delete all entries stored on this device',
+        deleteLocalWarning: 'This will permanently delete all entries stored on this device. This action cannot be undone.',
+        deleteLocalConfirmCheckbox: 'I understand all my local data will be permanently deleted',
+        deleteLocalSuccess: 'All local data has been deleted successfully',
+        deleteLocalButton: 'Delete Local Data',
+      },
 
       // About section
       about: 'About',

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -72,6 +72,8 @@ const EXPECTED_SETTINGS_KEYS = [
   'confirm',
   // Import/Export (nested object)
   'importExport',
+  // Cloud Data & Privacy (nested object)
+  'cloudDataPrivacy',
 ];
 
 /**


### PR DESCRIPTION
## Summary
Add GDPR-compliant data management section to Settings page, accessible to ALL users (signed in or not). Previously, data management was only available via the UserProfile dropdown for signed-in users with completed migration.

**Root cause:** GDPR Article 12 requires easily accessible data management. The single-path via avatar dropdown violated this.

**Fix:** New "Privacy & Data" section in SettingsPage with Export and Delete functionality. Removed migration status gate from UserProfile GDPR items.

Closes #133

## Changes
- `SettingsPage.jsx`: New Privacy & Data section with Export/Delete buttons and DataManagementDialog
- `UserProfile.jsx`: Removed migration status gate for GDPR items
- `LanguageProvider.jsx`: New bilingual translation keys for Privacy section
- Tests updated: 6 section headings, migration gate tests inverted

## Test Results
- All tests passing
- Lint: clean

## Checklist
- [x] Tests pass
- [x] Lint clean
- [ ] Manual test verified
- [ ] Hebrew RTL tested
- [ ] English LTR tested