### PR TITLE
Merge epic #41 Import/Export bug fixes to develop for staging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,6 +274,13 @@ function MainApp({ theme, cacheRtl }) {
     setCurrentTab(0);
   }, []);
 
+  // Navigate to a specific tab from within Settings (e.g., after import success)
+  const handleNavigateToTab = useCallback((tabIndex) => {
+    setShowSettings(false);
+    setEditEntry(null);
+    setCurrentTab(tabIndex);
+  }, []);
+
   // Show IndexedDB unavailable screen
   if (!indexedDBSupported) {
     return <IndexedDBUnavailable t={t} />;
@@ -306,7 +313,7 @@ function MainApp({ theme, cacheRtl }) {
     }
 
     if (showSettings) {
-      return <SettingsPage onBack={handleCloseSettings} />;
+      return <SettingsPage onBack={handleCloseSettings} onNavigateToTab={handleNavigateToTab} />;
     }
 
     switch (currentTab) {

--- a/src/components/ImportExportSection.jsx
+++ b/src/components/ImportExportSection.jsx
@@ -25,7 +25,7 @@ import { useEntries } from '../hooks/useEntries';
 import { useExportJSON, useExportCSV, useImport } from '../hooks/useImportExport';
 import ImportPreviewDialog from './ImportPreviewDialog';
 
-function ImportExportSection() {
+function ImportExportSection({ onNavigateToTab }) {
   const { t } = useLanguage();
   const { data: entries } = useEntries();
   const exportJSON = useExportJSON();
@@ -164,6 +164,7 @@ function ImportExportSection() {
         open={importHook.state !== 'idle'}
         importHook={importHook}
         onClose={handleDialogClose}
+        onNavigateToTab={onNavigateToTab}
       />
 
       {/* Snackbar for export feedback */}

--- a/src/components/ImportPreviewDialog.jsx
+++ b/src/components/ImportPreviewDialog.jsx
@@ -9,7 +9,7 @@
  * - Valid/invalid entry counts
  * - Sample entries table (first 5)
  * - Merge/Replace radio group
- * - Replace mode: warning alert + confirmation checkbox
+ * - Replace mode: backup info alert + warning alert + confirmation checkbox
  * - LinearProgress during import
  * - RTL support
  * - Accessible: aria-live, focus management, keyboard navigation
@@ -47,6 +47,7 @@ import {
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useLanguage } from '../contexts/useLanguage';
@@ -301,28 +302,33 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
               value={IMPORT_MODE_REPLACE}
               control={<Radio />}
               label={
-                <Box>
-                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                    {st.importModeReplace || 'Replace All'}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {st.importModeReplaceDesc || 'Delete all existing data and replace with imported data'}
-                  </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {st.importModeReplace || 'Replace All'}
+                      </Typography>
+                      <WarningAmberIcon fontSize="small" color="warning" />
+                    </Box>
+                    <Typography variant="caption" color="text.secondary">
+                      {st.importModeReplaceDesc || 'Delete all existing data and replace with imported data'}
+                    </Typography>
+                  </Box>
                 </Box>
               }
             />
           </RadioGroup>
         </FormControl>
 
-        {/* Replace mode warning */}
+        {/* Replace mode: backup info + destructive warning + consent checkbox */}
         {importMode === IMPORT_MODE_REPLACE && (
           <Box sx={{ mt: 1 }}>
+            <Alert severity="info" icon={<InfoOutlinedIcon />} sx={{ mb: 1 }}>
+              {st.importBackupNotice || 'A backup of your current data will be downloaded automatically before replacing.'}
+            </Alert>
             <Alert severity="warning" icon={<WarningAmberIcon />} sx={{ mb: 1 }}>
               {st.importReplaceWarning || 'This will permanently delete all your existing entries!'}
             </Alert>
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
-              {st.importAutoBackup || 'A backup of your current data will be downloaded first'}
-            </Typography>
             <FormControlLabel
               control={
                 <Checkbox
@@ -333,7 +339,7 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
               }
               label={
                 <Typography variant="body2">
-                  {st.importReplaceConfirm || 'I understand, replace all my data'}
+                  {st.importReplaceConfirm || 'I understand my data will be backed up and replaced'}
                 </Typography>
               }
             />

--- a/src/components/ImportPreviewDialog.jsx
+++ b/src/components/ImportPreviewDialog.jsx
@@ -70,7 +70,7 @@ function formatFileSize(bytes) {
   return `${mb.toFixed(1)} MB`;
 }
 
-function ImportPreviewDialog({ open, importHook, onClose }) {
+function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
   const { t, direction } = useLanguage();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -134,6 +134,18 @@ function ImportPreviewDialog({ open, importHook, onClose }) {
   const handleToggleInvalid = useCallback(() => {
     setShowInvalid((prev) => !prev);
   }, []);
+
+  const handleViewEntries = useCallback(() => {
+    // Reset dialog state, then navigate to History tab (tab 3)
+    setImportMode(IMPORT_MODE_MERGE);
+    setReplaceConfirmed(false);
+    setShowInvalid(false);
+    reset();
+    onClose();
+    if (onNavigateToTab) {
+      onNavigateToTab(3);
+    }
+  }, [reset, onClose, onNavigateToTab]);
 
   const canImport = state === ImportState.PREVIEW
     && parseResult?.validEntries?.length > 0
@@ -351,18 +363,36 @@ function ImportPreviewDialog({ open, importHook, onClose }) {
   const renderSuccess = () => (
     <>
       <DialogContent>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
+        <Box
+          sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}
+          role="status"
+          aria-live="polite"
+        >
           <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 2 }} />
           <Typography variant="h6" gutterBottom>
             {(st.importSuccess || 'Successfully imported {count} entries')
               .replace('{count}', String(importResult?.imported || 0))}
           </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {st.importSuccessHint || 'Your entries have been imported successfully'}
+          </Typography>
         </Box>
       </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={handleClose} variant="contained" sx={{ textTransform: 'none' }} size="large">
-          {st.cancel || t.cancel || 'Close'}
+      <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Button onClick={handleClose} sx={{ textTransform: 'none' }} size="large">
+          {st.done || 'Done'}
         </Button>
+        {onNavigateToTab && (
+          <Button
+            onClick={handleViewEntries}
+            variant="contained"
+            sx={{ textTransform: 'none' }}
+            size="large"
+            autoFocus
+          >
+            {st.viewEntries || 'View Entries'}
+          </Button>
+        )}
       </DialogActions>
     </>
   );

--- a/src/components/ImportPreviewDialog.test.jsx
+++ b/src/components/ImportPreviewDialog.test.jsx
@@ -61,6 +61,9 @@ const defaultTranslations = {
       importTitle: 'Import mode',
       cancel: 'Cancel',
       import: 'Import',
+      done: 'Done',
+      viewEntries: 'View Entries',
+      importSuccessHint: 'Your entries have been imported successfully',
     },
   },
   loading: 'Loading...',
@@ -356,7 +359,7 @@ describe('ImportPreviewDialog', () => {
         importResult: { imported: 10 },
       });
 
-      expect(screen.getByRole('button', { name: /Cancel|Close/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Done/i })).toBeInTheDocument();
     });
   });
 

--- a/src/components/ImportPreviewDialog.test.jsx
+++ b/src/components/ImportPreviewDialog.test.jsx
@@ -53,7 +53,8 @@ const defaultTranslations = {
       importModeReplace: 'Replace All',
       importModeReplaceDesc: 'Delete all existing data and replace with imported data',
       importReplaceWarning: 'This will permanently delete all your existing entries!',
-      importReplaceConfirm: 'I understand, replace all my data',
+      importReplaceConfirm: 'I understand my data will be backed up and replaced',
+      importBackupNotice: 'A backup of your current data will be downloaded automatically before replacing.',
       importAutoBackup: 'A backup of your current data will be downloaded first',
       importProgress: 'Importing... {current}/{total}',
       importSuccess: 'Successfully imported {count} entries',
@@ -258,7 +259,7 @@ describe('ImportPreviewDialog', () => {
 
       fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
 
-      expect(screen.getByText('I understand, replace all my data')).toBeInTheDocument();
+      expect(screen.getByText('I understand my data will be backed up and replaced')).toBeInTheDocument();
     });
 
     it('should disable Import button until replace is confirmed', () => {
@@ -278,12 +279,12 @@ describe('ImportPreviewDialog', () => {
       expect(screen.getByRole('button', { name: 'Import' })).not.toBeDisabled();
     });
 
-    it('should show auto-backup notice in replace mode', () => {
+    it('should show auto-backup notice as info alert in replace mode', () => {
       renderDialog({ state: 'preview', parseResult: sampleParseResult });
 
       fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
 
-      expect(screen.getByText('A backup of your current data will be downloaded first')).toBeInTheDocument();
+      expect(screen.getByText('A backup of your current data will be downloaded automatically before replacing.')).toBeInTheDocument();
     });
 
     it('should call executeImport with replace mode when confirmed and clicked', () => {
@@ -295,6 +296,55 @@ describe('ImportPreviewDialog', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Import' }));
 
       expect(executeImport).toHaveBeenCalledWith('replace');
+    });
+
+    it('should show backup info alert above destructive warning alert', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+
+      const alerts = screen.getAllByRole('alert');
+      const infoAlert = alerts.find(a => a.textContent.includes('backup'));
+      const warningAlert = alerts.find(a => a.textContent.includes('permanently delete'));
+
+      expect(infoAlert).toBeDefined();
+      expect(warningAlert).toBeDefined();
+
+      // Info alert should appear before warning alert in DOM order
+      const allAlerts = screen.getAllByRole('alert');
+      const infoIdx = allAlerts.indexOf(infoAlert);
+      const warnIdx = allAlerts.indexOf(warningAlert);
+      expect(infoIdx).toBeLessThan(warnIdx);
+    });
+
+    it('should not show backup notice or consent checkbox in merge mode', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      // Merge is default, no backup alert or checkbox should show
+      expect(screen.queryByText(/backup of your current data/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('should show warning icon next to Replace radio label', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
+    });
+
+    it('should reset checkbox when switching from replace to merge and back', () => {
+      renderDialog({ state: 'preview', parseResult: sampleParseResult });
+
+      // Switch to replace and check the checkbox
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+      fireEvent.click(screen.getByRole('checkbox'));
+      expect(screen.getByRole('checkbox')).toBeChecked();
+
+      // Switch to merge
+      fireEvent.click(screen.getByRole('radio', { name: /Merge/i }));
+
+      // Switch back to replace — checkbox should be unchecked
+      fireEvent.click(screen.getByRole('radio', { name: /Replace/i }));
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
     });
   });
 

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -84,7 +84,7 @@ function getTodayString() {
   return `${year}-${month}-${day}`;
 }
 
-export default function SettingsPage({ onBack }) {
+export default function SettingsPage({ onBack, onNavigateToTab }) {
   const { t, language, direction } = useLanguage();
   const {
     settings,
@@ -450,7 +450,7 @@ export default function SettingsPage({ onBack }) {
       </Paper>
 
       {/* Section 4: Data Management (Import/Export) */}
-      <ImportExportSection />
+      <ImportExportSection onNavigateToTab={onNavigateToTab} />
 
       {/* Section 5: About */}
       <Paper sx={{ p: 2 }}>

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -1,12 +1,13 @@
 /**
  * SettingsPage Component
  *
- * Full settings page with five sections:
+ * Full settings page with six sections:
  * 1. General (language, currency)
  * 2. Ma'aser Calculation (percentage management)
  * 3. Appearance (theme toggle)
  * 4. Data Management (import/export)
- * 5. About (version, links)
+ * 5. Cloud Data & Privacy (GDPR: export/delete data)
+ * 6. About (version, links)
  *
  * All settings auto-save immediately except ma'aser percentage
  * which requires confirmation via dialog.
@@ -14,12 +15,15 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import {
+  Alert,
   Box,
   Typography,
   IconButton,
   Select,
   MenuItem,
   FormControl,
+  FormControlLabel,
+  Checkbox,
   InputLabel,
   TextField,
   Slider,
@@ -41,6 +45,7 @@ import {
   ListItem,
   ListItemText,
   CircularProgress,
+  Snackbar,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -48,9 +53,18 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
+import SecurityIcon from '@mui/icons-material/Security';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useLanguage } from '../contexts/useLanguage';
 import { useSettings } from '../hooks/useSettings';
+import { useAuth } from '../hooks/useAuth';
+import { useQueryClient } from '@tanstack/react-query';
+import { clearAllEntries } from '../services/db';
+import { queryKeys } from '../hooks/useEntries';
 import ImportExportSection from './ImportExportSection';
+import DataManagementDialog from './DataManagementDialog';
 
 const APP_VERSION = '1.2.0';
 const GITHUB_URL = 'https://github.com/DubiWork/maaser-tracker';
@@ -95,14 +109,27 @@ export default function SettingsPage({ onBack, onNavigateToTab }) {
     updateMaaserPercentage,
     getCurrentMaaserPercentage,
   } = useSettings();
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
 
   const st = t.settings;
+  const cdp = st.cloudDataPrivacy || {};
 
   // Ma'aser percentage form state
   const [newPercentage, setNewPercentage] = useState(10);
   const [effectiveDate, setEffectiveDate] = useState(getTodayString);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [percentageError, setPercentageError] = useState('');
+
+  // GDPR Cloud Data & Privacy state
+  const [gdprDialogOpen, setGdprDialogOpen] = useState(false);
+  const [gdprDialogAction, setGdprDialogAction] = useState(null);
+
+  // Local data deletion state
+  const [deleteLocalDialogOpen, setDeleteLocalDialogOpen] = useState(false);
+  const [deleteLocalConfirmed, setDeleteLocalConfirmed] = useState(false);
+  const [isDeletingLocal, setIsDeletingLocal] = useState(false);
+  const [deleteLocalSnackbar, setDeleteLocalSnackbar] = useState({ open: false, message: '', severity: 'success' });
 
   const currentPercentage = useMemo(
     () => getCurrentMaaserPercentage(),
@@ -198,6 +225,63 @@ export default function SettingsPage({ onBack, onNavigateToTab }) {
 
   const handlePrivacyClick = useCallback(() => {
     window.location.hash = '#/privacy';
+  }, []);
+
+  // --- GDPR Cloud Data & Privacy Handlers ---
+
+  const handleGdprExportClick = useCallback(() => {
+    setGdprDialogAction('export');
+    setGdprDialogOpen(true);
+  }, []);
+
+  const handleGdprDeleteClick = useCallback(() => {
+    setGdprDialogAction('delete');
+    setGdprDialogOpen(true);
+  }, []);
+
+  const handleGdprDialogClose = useCallback(() => {
+    setGdprDialogOpen(false);
+    setGdprDialogAction(null);
+  }, []);
+
+  // --- Local Data Deletion Handlers ---
+
+  const handleDeleteLocalClick = useCallback(() => {
+    setDeleteLocalDialogOpen(true);
+    setDeleteLocalConfirmed(false);
+  }, []);
+
+  const handleDeleteLocalCancel = useCallback(() => {
+    setDeleteLocalDialogOpen(false);
+    setDeleteLocalConfirmed(false);
+  }, []);
+
+  const handleDeleteLocalConfirm = useCallback(async () => {
+    setIsDeletingLocal(true);
+    try {
+      await clearAllEntries();
+      queryClient.removeQueries({ queryKey: queryKeys.all });
+      await queryClient.refetchQueries({ queryKey: queryKeys.all, type: 'all' });
+      setDeleteLocalDialogOpen(false);
+      setDeleteLocalConfirmed(false);
+      setDeleteLocalSnackbar({
+        open: true,
+        message: cdp.deleteLocalSuccess || 'All local data has been deleted successfully',
+        severity: 'success',
+      });
+    } catch {
+      setDeleteLocalSnackbar({
+        open: true,
+        message: st.errorSavingSettings || 'An error occurred',
+        severity: 'error',
+      });
+    } finally {
+      setIsDeletingLocal(false);
+    }
+  }, [cdp.deleteLocalSuccess, st.errorSavingSettings, queryClient]);
+
+  const handleDeleteLocalSnackbarClose = useCallback(() => {
+    setDeleteLocalSnackbar((prev) => ({ ...prev, open: false }));
   }, []);
 
   // Currency label helper
@@ -452,7 +536,83 @@ export default function SettingsPage({ onBack, onNavigateToTab }) {
       {/* Section 4: Data Management (Import/Export) */}
       <ImportExportSection onNavigateToTab={onNavigateToTab} />
 
-      {/* Section 5: About */}
+      {/* Section 5: Cloud Data & Privacy (GDPR) */}
+      <Paper sx={{ p: 2, mb: 2 }} data-testid="cloud-data-privacy-section">
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <SecurityIcon color="action" fontSize="small" />
+          <Typography variant="h6" component="h2" sx={{ fontWeight: 500 }}>
+            {cdp.title || 'Cloud Data & Privacy'}
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {cdp.description || 'Export or delete your cloud data'}
+        </Typography>
+
+        {user ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Button
+              variant="outlined"
+              startIcon={<CloudDownloadIcon />}
+              onClick={handleGdprExportClick}
+              sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5 }}
+              aria-label={cdp.exportMyData || 'Export My Data'}
+            >
+              <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {cdp.exportMyData || 'Export My Data'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {cdp.exportDescription || 'Download all your cloud data as a JSON file'}
+                </Typography>
+              </Box>
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteForeverIcon />}
+              onClick={handleGdprDeleteClick}
+              sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5 }}
+              aria-label={cdp.deleteAllData || 'Delete All Data'}
+            >
+              <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+                <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                  {cdp.deleteAllData || 'Delete All Data'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {cdp.deleteDescription || 'Permanently delete all your cloud data'}
+                </Typography>
+              </Box>
+            </Button>
+          </Box>
+        ) : (
+          <Alert severity="info" sx={{ mt: 1 }}>
+            {cdp.signInToManage || 'Sign in to manage your cloud data'}
+          </Alert>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Local data deletion - available to all users */}
+        <Button
+          variant="outlined"
+          color="error"
+          startIcon={<DeleteOutlineIcon />}
+          onClick={handleDeleteLocalClick}
+          sx={{ textTransform: 'none', justifyContent: 'flex-start', py: 1.5, width: '100%' }}
+          aria-label={cdp.deleteLocalData || 'Delete Local Data'}
+        >
+          <Box sx={{ textAlign: direction === 'rtl' ? 'right' : 'left' }}>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {cdp.deleteLocalData || 'Delete Local Data'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {cdp.deleteLocalDescription || 'Delete all entries stored on this device'}
+            </Typography>
+          </Box>
+        </Button>
+      </Paper>
+
+      {/* Section 6: About */}
       <Paper sx={{ p: 2 }}>
         <Typography variant="h6" component="h2" sx={{ fontWeight: 500, mb: 2 }}>
           {st.about}
@@ -512,6 +672,78 @@ export default function SettingsPage({ onBack, onNavigateToTab }) {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* GDPR Data Management Dialog (cloud export/delete) */}
+      <DataManagementDialog
+        open={gdprDialogOpen}
+        onClose={handleGdprDialogClose}
+        initialAction={gdprDialogAction}
+      />
+
+      {/* Local data deletion confirmation dialog */}
+      <Dialog
+        open={deleteLocalDialogOpen}
+        onClose={isDeletingLocal ? undefined : handleDeleteLocalCancel}
+        dir={direction}
+        aria-labelledby="delete-local-dialog-title"
+        disableEscapeKeyDown={isDeletingLocal}
+      >
+        <DialogTitle id="delete-local-dialog-title">
+          {cdp.deleteLocalData || 'Delete Local Data'}
+        </DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {cdp.deleteLocalWarning || 'This will permanently delete all entries stored on this device. This action cannot be undone.'}
+          </Alert>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={deleteLocalConfirmed}
+                onChange={(e) => setDeleteLocalConfirmed(e.target.checked)}
+                color="error"
+                disabled={isDeletingLocal}
+              />
+            }
+            label={cdp.deleteLocalConfirmCheckbox || 'I understand all my local data will be permanently deleted'}
+          />
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: 'space-between', px: 3, pb: 2 }}>
+          <Button
+            onClick={handleDeleteLocalCancel}
+            disabled={isDeletingLocal}
+            sx={{ textTransform: 'none' }}
+          >
+            {t.cancel}
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            startIcon={isDeletingLocal ? <CircularProgress size={16} color="inherit" /> : <DeleteForeverIcon />}
+            disabled={!deleteLocalConfirmed || isDeletingLocal}
+            onClick={handleDeleteLocalConfirm}
+            sx={{ textTransform: 'none' }}
+          >
+            {cdp.deleteLocalButton || 'Delete Local Data'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Snackbar for local deletion feedback */}
+      <Snackbar
+        open={deleteLocalSnackbar.open}
+        autoHideDuration={4000}
+        onClose={handleDeleteLocalSnackbarClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleDeleteLocalSnackbarClose}
+          severity={deleteLocalSnackbar.severity}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {deleteLocalSnackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/components/SettingsPage.test.jsx
+++ b/src/components/SettingsPage.test.jsx
@@ -1,9 +1,9 @@
 /**
  * Tests for SettingsPage and SettingsButton components
  *
- * Covers all five sections (General, Ma'aser Calculation, Appearance,
- * Data Management, About), navigation, auto-save pattern, confirmation dialog,
- * percentage history, bilingual support, and accessibility.
+ * Covers all six sections (General, Ma'aser Calculation, Appearance,
+ * Data Management, Cloud Data & Privacy, About), navigation, auto-save pattern,
+ * confirmation dialog, percentage history, bilingual support, and accessibility.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,6 +18,35 @@ import SettingsButton from './SettingsButton';
 vi.mock('./ImportExportSection', () => ({
   default: () => <div data-testid="import-export-section"><h2>Data Management</h2></div>,
 }));
+
+// Mock DataManagementDialog since it has its own test suite
+vi.mock('./DataManagementDialog', () => ({
+  default: ({ open }) => open ? <div data-testid="data-management-dialog">DataManagementDialog</div> : null,
+}));
+
+// Mock useAuth hook
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: null })),
+}));
+
+// Mock db service
+vi.mock('../services/db', () => ({
+  clearAllEntries: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock useEntries queryKeys
+vi.mock('../hooks/useEntries', () => ({
+  queryKeys: {
+    all: ['entries'],
+    lists: () => ['entries', 'list'],
+    list: (filters) => ['entries', 'list', filters],
+    details: () => ['entries', 'detail'],
+    detail: (id) => ['entries', 'detail', id],
+    migrationStatus: (userId) => ['migration', 'status', userId],
+  },
+}));
+
+import { useAuth } from '../hooks/useAuth';
 
 // Mock IndexedDB settings service
 vi.mock('../services/settingsDb', () => ({
@@ -594,7 +623,7 @@ describe('SettingsPage', () => {
 
       // h2: Section headings
       const h2s = screen.getAllByRole('heading', { level: 2 });
-      expect(h2s.length).toBe(5);
+      expect(h2s.length).toBe(6);
     });
 
     it('should have aria-label on back button', async () => {

--- a/src/components/SettingsPage.test.jsx
+++ b/src/components/SettingsPage.test.jsx
@@ -46,8 +46,6 @@ vi.mock('../hooks/useEntries', () => ({
   },
 }));
 
-import { useAuth } from '../hooks/useAuth';
-
 // Mock IndexedDB settings service
 vi.mock('../services/settingsDb', () => ({
   getSettings: vi.fn(),

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -175,30 +175,26 @@ function UserProfile() {
           />
         </MenuItem>
 
-        {/* GDPR data management - only when cloud sync completed */}
-        {migrationStatus === 'completed' && (
-          <>
-            <Divider />
-            <MenuItem onClick={handleExportClick}>
-              <ListItemIcon>
-                <FileUploadIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText
-                primary={t.dataManagement?.exportMyData || 'Export my data'}
-                primaryTypographyProps={{ variant: 'body2' }}
-              />
-            </MenuItem>
-            <MenuItem onClick={handleDeleteClick}>
-              <ListItemIcon>
-                <DeleteForeverIcon fontSize="small" color="error" />
-              </ListItemIcon>
-              <ListItemText
-                primary={t.dataManagement?.deleteCloudData || 'Delete cloud data'}
-                primaryTypographyProps={{ variant: 'body2', color: 'error.main' }}
-              />
-            </MenuItem>
-          </>
-        )}
+        {/* GDPR data management - available to all authenticated users */}
+        <Divider />
+        <MenuItem onClick={handleExportClick}>
+          <ListItemIcon>
+            <FileUploadIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText
+            primary={t.dataManagement?.exportMyData || 'Export my data'}
+            primaryTypographyProps={{ variant: 'body2' }}
+          />
+        </MenuItem>
+        <MenuItem onClick={handleDeleteClick}>
+          <ListItemIcon>
+            <DeleteForeverIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText
+            primary={t.dataManagement?.deleteCloudData || 'Delete cloud data'}
+            primaryTypographyProps={{ variant: 'body2', color: 'error.main' }}
+          />
+        </MenuItem>
 
         <Divider />
 

--- a/src/components/UserProfile.test.jsx
+++ b/src/components/UserProfile.test.jsx
@@ -436,31 +436,31 @@ describe('UserProfile', () => {
       expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is idle', () => {
+    it('should show GDPR menu items when migrationStatus is idle (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'idle' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is in-progress', () => {
+    it('should show GDPR menu items when migrationStatus is in-progress (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'in-progress' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
-    it('should NOT show GDPR menu items when migrationStatus is failed', () => {
+    it('should show GDPR menu items when migrationStatus is failed (no migration gate)', () => {
       useMigration.mockReturnValue({ status: 'failed' });
       renderWithAuth(<UserProfile />, testUser);
       openMenu();
 
-      expect(screen.queryByText('ייצוא הנתונים שלי')).not.toBeInTheDocument();
-      expect(screen.queryByText('מחיקת נתוני הענן')).not.toBeInTheDocument();
+      expect(screen.getByText('ייצוא הנתונים שלי')).toBeInTheDocument();
+      expect(screen.getByText('מחיקת נתוני הענן')).toBeInTheDocument();
     });
 
     it('should have FileUploadIcon SVG on export menu item', () => {

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -414,6 +414,10 @@ const translations = {
         iosSaveHint: 'הקש על סמל השיתוף כדי לשמור את הקובץ',
         cancel: 'ביטול',
         import: 'ייבוא',
+        // Success dialog actions
+        done: 'סיום',
+        viewEntries: 'צפה ברשומות',
+        importSuccessHint: 'הרשומות שלך יובאו בהצלחה',
       },
     },
   },
@@ -817,6 +821,10 @@ const translations = {
         iosSaveHint: 'Tap the share icon to save the file',
         cancel: 'Cancel',
         import: 'Import',
+        // Success dialog actions
+        done: 'Done',
+        viewEntries: 'View Entries',
+        importSuccessHint: 'Your entries have been imported successfully',
       },
     },
   },

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -401,7 +401,8 @@ const translations = {
         importModeReplace: 'החלף הכל',
         importModeReplaceDesc: 'מחק את כל הנתונים הקיימים והחלף בנתונים המיובאים',
         importReplaceWarning: 'פעולה זו תמחק לצמיתות את כל הרשומות הקיימות שלך!',
-        importReplaceConfirm: 'אני מבין/ה, החלף את כל הנתונים שלי',
+        importReplaceConfirm: 'אני מבין/ה שהנתונים שלי יגובו ויוחלפו',
+        importBackupNotice: 'גיבוי של הנתונים הנוכחיים שלך יורד אוטומטית לפני ההחלפה.',
         importAutoBackup: 'גיבוי של הנתונים הנוכחיים שלך יורד תחילה',
         // Progress & results
         importProgress: 'מייבא... {current}/{total}',
@@ -808,7 +809,8 @@ const translations = {
         importModeReplace: 'Replace All',
         importModeReplaceDesc: 'Delete all existing data and replace with imported data',
         importReplaceWarning: 'This will permanently delete all your existing entries!',
-        importReplaceConfirm: 'I understand, replace all my data',
+        importReplaceConfirm: 'I understand my data will be backed up and replaced',
+        importBackupNotice: 'A backup of your current data will be downloaded automatically before replacing.',
         importAutoBackup: 'A backup of your current data will be downloaded first',
         // Progress & results
         importProgress: 'Importing... {current}/{total}',

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -352,6 +352,23 @@ const translations = {
       deleteAccountConfirm: 'האם אתה בטוח שברצונך למחוק את החשבון? פעולה זו לא ניתנת לביטול.',
       actionCannotBeUndone: 'פעולה זו לא ניתנת לביטול',
 
+      // Cloud Data & Privacy section (GDPR)
+      cloudDataPrivacy: {
+        title: 'נתוני ענן ופרטיות',
+        description: 'ייצוא או מחיקת נתוני הענן שלך',
+        exportMyData: 'ייצוא הנתונים שלי',
+        exportDescription: 'הורד את כל נתוני הענן שלך כקובץ JSON',
+        deleteAllData: 'מחיקת כל הנתונים',
+        deleteDescription: 'מחק לצמיתות את כל נתוני הענן שלך',
+        signInToManage: 'התחבר/י כדי לנהל את נתוני הענן שלך',
+        deleteLocalData: 'מחיקת נתונים מקומיים',
+        deleteLocalDescription: 'מחק את כל הרשומות השמורות במכשיר זה',
+        deleteLocalWarning: 'פעולה זו תמחק לצמיתות את כל הרשומות השמורות במכשיר זה. פעולה זו לא ניתנת לביטול.',
+        deleteLocalConfirmCheckbox: 'אני מבין/ה שכל הנתונים המקומיים שלי יימחקו לצמיתות',
+        deleteLocalSuccess: 'כל הנתונים המקומיים נמחקו בהצלחה',
+        deleteLocalButton: 'מחק נתונים מקומיים',
+      },
+
       // About section
       about: 'אודות',
       version: 'גרסה',
@@ -759,6 +776,23 @@ const translations = {
       clearDataConfirm: 'Are you sure you want to clear all data?',
       deleteAccountConfirm: 'Are you sure you want to delete your account? This action cannot be undone.',
       actionCannotBeUndone: 'This action cannot be undone',
+
+      // Cloud Data & Privacy section (GDPR)
+      cloudDataPrivacy: {
+        title: 'Cloud Data & Privacy',
+        description: 'Export or delete your cloud data',
+        exportMyData: 'Export My Data',
+        exportDescription: 'Download all your cloud data as a JSON file',
+        deleteAllData: 'Delete All Data',
+        deleteDescription: 'Permanently delete all your cloud data',
+        signInToManage: 'Sign in to manage your cloud data',
+        deleteLocalData: 'Delete Local Data',
+        deleteLocalDescription: 'Delete all entries stored on this device',
+        deleteLocalWarning: 'This will permanently delete all entries stored on this device. This action cannot be undone.',
+        deleteLocalConfirmCheckbox: 'I understand all my local data will be permanently deleted',
+        deleteLocalSuccess: 'All local data has been deleted successfully',
+        deleteLocalButton: 'Delete Local Data',
+      },
 
       // About section
       about: 'About',

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -322,6 +322,9 @@ describe('Settings Translation Keys', () => {
       'iosSaveHint',
       'cancel',
       'import',
+      'done',
+      'viewEntries',
+      'importSuccessHint',
     ];
 
     it('should have importExport as a nested object in both languages', () => {

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -72,6 +72,8 @@ const EXPECTED_SETTINGS_KEYS = [
   'confirm',
   // Import/Export (nested object)
   'importExport',
+  // Cloud Data & Privacy (nested object)
+  'cloudDataPrivacy',
 ];
 
 /**

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -312,6 +312,7 @@ describe('Settings Translation Keys', () => {
       'importModeReplaceDesc',
       'importReplaceWarning',
       'importReplaceConfirm',
+      'importBackupNotice',
       'importAutoBackup',
       'importProgress',
       'importSuccess',

--- a/src/hooks/useImportExport.js
+++ b/src/hooks/useImportExport.js
@@ -190,8 +190,10 @@ export function useImport() {
       if (result.success) {
         setImportResult(result);
         setState(ImportState.SUCCESS);
-        // Invalidate entries cache so UI refreshes
-        await queryClient.invalidateQueries({ queryKey: queryKeys.all });
+        // Remove cached entries entirely so Dashboard/History fetch fresh data on mount.
+        // invalidateQueries only marks stale — unmounted queries won't refetch,
+        // and 5-min staleTime may serve pre-import data on remount.
+        queryClient.removeQueries({ queryKey: queryKeys.all });
       } else {
         setState(ImportState.ERROR);
         setError(result.errors?.[0] || 'Import failed');

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -172,6 +172,31 @@ describe('exportToJSON', () => {
     expect(parsed.entries[0].id).toBe('e1');
     expect(parsed.entries[0]).not.toHaveProperty('note');
   });
+
+  it('should normalize ISO datetime to YYYY-MM-DD (#131)', () => {
+    const entries = [makeEntry({ date: '2026-03-01T00:00:00.000Z' })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].date).toBe('2026-03-01');
+  });
+
+  it('should keep YYYY-MM-DD dates unchanged (#131)', () => {
+    const entries = [makeEntry({ date: '2026-06-15' })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].date).toBe('2026-06-15');
+  });
+
+  it('should not mutate original entry date during normalization (#131)', () => {
+    const original = makeEntry({ date: '2026-03-01T00:00:00.000Z' });
+    const entries = [original];
+    exportToJSON(entries);
+    expect(original.date).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('should include maaser field in JSON export (#132)', () => {
+    const entries = [makeEntry({ maaser: 500 })];
+    const parsed = JSON.parse(exportToJSON(entries));
+    expect(parsed.entries[0].maaser).toBe(500);
+  });
 });
 
 // --- exportToCSV ---
@@ -191,8 +216,24 @@ describe('exportToCSV', () => {
     expect(firstLine).toContain('type');
     expect(firstLine).toContain('date');
     expect(firstLine).toContain('amount');
+    expect(firstLine).toContain('maaser');
     expect(firstLine).toContain('note');
     expect(firstLine).toContain('accountingMonth');
+  });
+
+  it('should include maaser column with correct values (#132)', async () => {
+    const entries = [makeEntry({ maaser: 500 })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('maaser');
+    expect(result).toContain('500');
+  });
+
+  it('should handle entries without maaser field in CSV (#132)', async () => {
+    const entries = [makeEntry({ type: 'donation' })];
+    const result = await exportToCSV(entries);
+    // Header should still be present even if entry has no maaser value
+    const firstLine = result.replace('\uFEFF', '').split('\n')[0];
+    expect(firstLine).toContain('maaser');
   });
 
   it('should include entry data in CSV output', async () => {
@@ -273,6 +314,20 @@ describe('exportToCSV', () => {
     const entries = [makeEntry({ note: 'משכורת חודשית' })];
     const result = await exportToCSV(entries);
     expect(result).toContain('משכורת חודשית');
+  });
+
+  it('should normalize ISO datetime to YYYY-MM-DD in CSV (#131)', async () => {
+    const entries = [makeEntry({ date: '2026-03-01T00:00:00.000Z' })];
+    const result = await exportToCSV(entries);
+    // Should contain the normalized date, not the full ISO string
+    expect(result).toContain('2026-03-01');
+    expect(result).not.toContain('T00:00:00');
+  });
+
+  it('should keep YYYY-MM-DD dates unchanged in CSV (#131)', async () => {
+    const entries = [makeEntry({ date: '2026-06-15' })];
+    const result = await exportToCSV(entries);
+    expect(result).toContain('2026-06-15');
   });
 });
 

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -19,7 +19,23 @@ const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@'];
 const UTF8_BOM = '\uFEFF';
 
 /** CSV column headers (English) */
-const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'note', 'accountingMonth'];
+const CSV_HEADERS = ['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth'];
+
+/**
+ * Normalize a date value to YYYY-MM-DD format.
+ * Handles full ISO strings (e.g., "2026-03-01T00:00:00.000Z") and
+ * plain date strings (e.g., "2026-03-01").
+ * @param {string} dateValue - Date string to normalize
+ * @returns {string} Date in YYYY-MM-DD format, or original value if not parseable
+ */
+function normalizeDateToYMD(dateValue) {
+  if (!dateValue || typeof dateValue !== 'string') return dateValue;
+  try {
+    return new Date(dateValue).toISOString().split('T')[0];
+  } catch {
+    return dateValue;
+  }
+}
 
 /**
  * Strip internal/server-side fields from an entry for export.
@@ -30,6 +46,20 @@ function stripInternalFields(entry) {
   const cleaned = { ...entry };
   for (const field of INTERNAL_FIELDS) {
     delete cleaned[field];
+  }
+  return cleaned;
+}
+
+/**
+ * Prepare an entry for export by stripping internal fields
+ * and normalizing the date to YYYY-MM-DD format.
+ * @param {Object} entry - Entry object to prepare
+ * @returns {Object} Cleaned entry with normalized date
+ */
+function prepareEntryForExport(entry) {
+  const cleaned = stripInternalFields(entry);
+  if (cleaned.date) {
+    cleaned.date = normalizeDateToYMD(cleaned.date);
   }
   return cleaned;
 }
@@ -88,7 +118,7 @@ export function exportToJSON(entries) {
     throw new Error('No entries to export');
   }
 
-  const cleanedEntries = entries.map(stripInternalFields);
+  const cleanedEntries = entries.map(prepareEntryForExport);
 
   const envelope = {
     version: EXPORT_SCHEMA_VERSION,
@@ -117,7 +147,7 @@ export async function exportToCSV(entries) {
 
   const Papa = await import('papaparse');
 
-  const cleanedEntries = entries.map(stripInternalFields);
+  const cleanedEntries = entries.map(prepareEntryForExport);
   const sanitizedEntries = cleanedEntries.map(sanitizeEntryForCsv);
 
   const csv = Papa.default.unparse(sanitizedEntries, {


### PR DESCRIPTION
## Summary
Merges 5 bug fixes from epic/41-import-export-bugfix to develop:

- **#129** (P0): Fix import cache invalidation — entries now appear after import
- **#130** (P1): Add backup consent step before import replace
- **#131** (P2): Normalize export dates to YYYY-MM-DD
- **#132** (P2): Add missing maaser column to CSV export
- **#133** (P1): Add GDPR data management section to Settings page

Closes #129, Closes #130, Closes #131, Closes #132, Closes #133

## Changes
- Import: `removeQueries` replaces `invalidateQueries`, success dialog with "View Entries" navigation
- Import: Info Alert + consent checkbox for Replace mode backup
- Export: `maaser` added to CSV headers, dates normalized to YYYY-MM-DD
- Settings: New "Privacy & Data" section with Export/Delete for all users
- UserProfile: Removed migration status gate for GDPR items
- 20+ new bilingual translation keys
- Tests updated across all changes

## Test Results
- All 1846 tests passing (1 skipped)
- Lint: clean

## #134 (Offline UX) deferred to next sprint per grooming plan