### PR TITLE
#147 Add column mapping translation keys (bilingual)

### DIFF
--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -437,6 +437,59 @@ const translations = {
         viewEntries: 'צפה ברשומות',
         importSuccessHint: 'הרשומות שלך יובאו בהצלחה',
       },
+
+      // External CSV Import — Column Mapping
+      externalImport: {
+        // Wizard step labels
+        externalCsvDetected: 'זוהה קובץ CSV חיצוני',
+        mapColumns: 'מיפוי עמודות',
+        mapColumnsDescription: 'התאם את עמודות ה-CSV לשדות האפליקציה',
+        autoDetected: 'זוהה אוטומטית',
+
+        // Column names
+        dateColumn: 'תאריך',
+        incomeColumn: 'סכום הכנסה',
+        maaserColumn: 'מעשר (10%)',
+        donationColumn: 'סכום תרומה',
+
+        // Confidence labels
+        highConfidence: 'ביטחון גבוה',
+        mediumConfidence: 'ביטחון בינוני',
+        lowConfidence: 'ביטחון נמוך',
+        unmapped: 'לא ממופה',
+
+        // Actions
+        skipColumn: 'דלג על עמודה זו',
+        changeMapping: 'שנה מיפוי',
+        confirmMapping: 'אשר מיפוי',
+        backToFileSelect: 'חזרה לבחירת קובץ',
+
+        // Preview
+        previewMappedData: 'תצוגה מקדימה של נתונים ממופים',
+        showingFirstRows: 'מציג {count} שורות ראשונות',
+        rawValue: 'ערך מקורי',
+        mappedValue: 'ערך ממופה',
+
+        // Import summary
+        rowsToImport: 'שורות לייבוא',
+        incomeEntries: 'רשומות הכנסה',
+        donationEntries: 'רשומות תרומה',
+        skippedRows: 'שורות שדולגו',
+        totalEntries: 'סה״כ רשומות ליצירה',
+
+        // Errors
+        noDateColumn: 'עמודת תאריך נדרשת',
+        noIncomeColumn: 'עמודת הכנסה נדרשת',
+        duplicateMapping: 'עמודה כבר ממופה לשדה אחר',
+        parseError: 'לא ניתן לפענח ערך בשורה {row}',
+        currencyParseError: 'פורמט מטבע לא תקין',
+        dateParseError: 'פורמט תאריך לא תקין',
+        noValidRows: 'לא נמצאו שורות תקינות לייבוא',
+
+        // Help text
+        columnMappingHelp: 'בחר איזו עמודה ב-CSV מתאימה לכל שדה. העמודות מזוהות אוטומטית מהכותרות.',
+        externalCsvHelp: 'נראה שקובץ ה-CSV שלך הגיע ממקור חיצוני (למשל Google Sheets). נעזור לך למפות את העמודות כדי לייבא את הנתונים.',
+      },
     },
   },
   en: {
@@ -861,6 +914,59 @@ const translations = {
         done: 'Done',
         viewEntries: 'View Entries',
         importSuccessHint: 'Your entries have been imported successfully',
+      },
+
+      // External CSV Import — Column Mapping
+      externalImport: {
+        // Wizard step labels
+        externalCsvDetected: 'External CSV format detected',
+        mapColumns: 'Map Columns',
+        mapColumnsDescription: 'Match your CSV columns to the app fields',
+        autoDetected: 'Auto-detected',
+
+        // Column names
+        dateColumn: 'Date',
+        incomeColumn: 'Income Amount',
+        maaserColumn: 'Ma\'aser (10%)',
+        donationColumn: 'Donation Amount',
+
+        // Confidence labels
+        highConfidence: 'High confidence',
+        mediumConfidence: 'Medium confidence',
+        lowConfidence: 'Low confidence',
+        unmapped: 'Not mapped',
+
+        // Actions
+        skipColumn: 'Skip this column',
+        changeMapping: 'Change mapping',
+        confirmMapping: 'Confirm Mapping',
+        backToFileSelect: 'Back to file selection',
+
+        // Preview
+        previewMappedData: 'Preview mapped data',
+        showingFirstRows: 'Showing first {count} rows',
+        rawValue: 'Raw value',
+        mappedValue: 'Mapped value',
+
+        // Import summary
+        rowsToImport: 'Rows to import',
+        incomeEntries: 'Income entries',
+        donationEntries: 'Donation entries',
+        skippedRows: 'Skipped rows',
+        totalEntries: 'Total entries to create',
+
+        // Errors
+        noDateColumn: 'Date column is required',
+        noIncomeColumn: 'Income column is required',
+        duplicateMapping: 'Column already mapped to another field',
+        parseError: 'Could not parse value in row {row}',
+        currencyParseError: 'Invalid currency format',
+        dateParseError: 'Invalid date format',
+        noValidRows: 'No valid rows found to import',
+
+        // Help text
+        columnMappingHelp: 'Select which column in your CSV corresponds to each field. Columns are auto-detected from headers.',
+        externalCsvHelp: 'Your CSV appears to be from an external source (e.g., Google Sheets). We\'ll help you map the columns to import your data.',
       },
     },
   },

--- a/src/contexts/LanguageProvider.settings.test.jsx
+++ b/src/contexts/LanguageProvider.settings.test.jsx
@@ -74,6 +74,8 @@ const EXPECTED_SETTINGS_KEYS = [
   'importExport',
   // Cloud Data & Privacy (nested object)
   'cloudDataPrivacy',
+  // External CSV Import — Column Mapping (nested object)
+  'externalImport',
 ];
 
 /**
@@ -400,6 +402,115 @@ describe('Settings Translation Keys', () => {
       // Verify importExport keys do not collide with top-level dataManagement keys
       expect(heSettings.importExport).not.toBe(heSettings.dataManagement);
       expect(enSettings.importExport).not.toBe(enSettings.dataManagement);
+    });
+  });
+
+  describe('External CSV Import translations (settings.externalImport)', () => {
+    const EXPECTED_EXTERNAL_IMPORT_KEYS = [
+      // Wizard step labels
+      'externalCsvDetected',
+      'mapColumns',
+      'mapColumnsDescription',
+      'autoDetected',
+      // Column names
+      'dateColumn',
+      'incomeColumn',
+      'maaserColumn',
+      'donationColumn',
+      // Confidence labels
+      'highConfidence',
+      'mediumConfidence',
+      'lowConfidence',
+      'unmapped',
+      // Actions
+      'skipColumn',
+      'changeMapping',
+      'confirmMapping',
+      'backToFileSelect',
+      // Preview
+      'previewMappedData',
+      'showingFirstRows',
+      'rawValue',
+      'mappedValue',
+      // Import summary
+      'rowsToImport',
+      'incomeEntries',
+      'donationEntries',
+      'skippedRows',
+      'totalEntries',
+      // Errors
+      'noDateColumn',
+      'noIncomeColumn',
+      'duplicateMapping',
+      'parseError',
+      'currencyParseError',
+      'dateParseError',
+      'noValidRows',
+      // Help text
+      'columnMappingHelp',
+      'externalCsvHelp',
+    ];
+
+    it('should have externalImport as a nested object in both languages', () => {
+      expect(typeof heSettings.externalImport).toBe('object');
+      expect(typeof enSettings.externalImport).toBe('object');
+    });
+
+    it('should contain all expected external import keys in Hebrew', () => {
+      for (const key of EXPECTED_EXTERNAL_IMPORT_KEYS) {
+        expect(heSettings.externalImport).toHaveProperty(key);
+      }
+    });
+
+    it('should contain all expected external import keys in English', () => {
+      for (const key of EXPECTED_EXTERNAL_IMPORT_KEYS) {
+        expect(enSettings.externalImport).toHaveProperty(key);
+      }
+    });
+
+    it('should have identical key sets in both languages', () => {
+      const heKeys = Object.keys(heSettings.externalImport).sort();
+      const enKeys = Object.keys(enSettings.externalImport).sort();
+      expect(heKeys).toEqual(enKeys);
+    });
+
+    it('should have the expected number of external import keys', () => {
+      expect(Object.keys(heSettings.externalImport).length).toBe(EXPECTED_EXTERNAL_IMPORT_KEYS.length);
+      expect(Object.keys(enSettings.externalImport).length).toBe(EXPECTED_EXTERNAL_IMPORT_KEYS.length);
+    });
+
+    it('should have non-empty string values for all external import keys', () => {
+      for (const key of EXPECTED_EXTERNAL_IMPORT_KEYS) {
+        expect(typeof heSettings.externalImport[key]).toBe('string');
+        expect(heSettings.externalImport[key].trim().length).toBeGreaterThan(0);
+        expect(typeof enSettings.externalImport[key]).toBe('string');
+        expect(enSettings.externalImport[key].trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have proper Hebrew content for external import keys', () => {
+      expect(heSettings.externalImport.mapColumns).toBe('מיפוי עמודות');
+      expect(heSettings.externalImport.confirmMapping).toBe('אשר מיפוי');
+      expect(heSettings.externalImport.noDateColumn).toBe('עמודת תאריך נדרשת');
+    });
+
+    it('should have proper English content for external import keys', () => {
+      expect(enSettings.externalImport.mapColumns).toBe('Map Columns');
+      expect(enSettings.externalImport.confirmMapping).toBe('Confirm Mapping');
+      expect(enSettings.externalImport.noDateColumn).toBe('Date column is required');
+    });
+
+    it('should have matching template placeholders in both languages', () => {
+      const templateKeys = [
+        'showingFirstRows',
+        'parseError',
+      ];
+
+      for (const key of templateKeys) {
+        const hePlaceholders = (heSettings.externalImport[key].match(/\{[^}]+\}/g) || []).sort();
+        const enPlaceholders = (enSettings.externalImport[key].match(/\{[^}]+\}/g) || []).sort();
+        expect(hePlaceholders).toEqual(enPlaceholders);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add ~35 translation keys under `settings.externalImport` for the column mapping UI
- Both Hebrew and English translations for: wizard steps, column names, confidence labels, actions, preview, import summary, errors, and help text
- Update settings translation test suite with 10 new test cases for `externalImport` keys

Closes #147
Part of epic #142