### PR TITLE
#146 Import state machine — add MAPPING step to external import flow

### DIFF
--- a/src/components/ImportPreviewDialog.jsx
+++ b/src/components/ImportPreviewDialog.jsx
@@ -2,7 +2,10 @@
  * ImportPreviewDialog Component
  *
  * State-machine dialog for previewing and executing data imports.
- * States: IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ * States: IDLE -> PARSING -> [COLUMN_MAPPING ->] PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ *
+ * External CSVs route through COLUMN_MAPPING for user-driven column mapping.
+ * App-format CSVs and JSON files skip directly to PREVIEW.
  *
  * Features:
  * - File info display
@@ -53,6 +56,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useLanguage } from '../contexts/useLanguage';
 import { ImportState } from '../hooks/useImportExport';
 import { IMPORT_MODE_MERGE, IMPORT_MODE_REPLACE } from '../services/importService';
+import ColumnMappingStep from './ColumnMappingStep';
 
 /** Maximum number of sample entries to display in preview */
 const MAX_SAMPLE_ENTRIES = 5;
@@ -84,7 +88,10 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
     importResult,
     error,
     progress,
+    externalCSVData,
     executeImport,
+    confirmMapping,
+    goBackToFileSelect,
     reset,
     retry,
   } = importHook;
@@ -132,6 +139,14 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
     retry();
   }, [retry]);
 
+  const handleColumnMappingConfirm = useCallback((finalMappings) => {
+    confirmMapping(finalMappings);
+  }, [confirmMapping]);
+
+  const handleColumnMappingBack = useCallback(() => {
+    goBackToFileSelect();
+  }, [goBackToFileSelect]);
+
   const handleToggleInvalid = useCallback(() => {
     setShowInvalid((prev) => !prev);
   }, []);
@@ -156,6 +171,10 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
     switch (state) {
       case ImportState.PARSING:
         return st.importPreviewTitle || 'Import Preview';
+      case ImportState.COLUMN_MAPPING: {
+        const ext = t.settings?.externalImport || {};
+        return ext.mapColumns || 'Map Columns';
+      }
       case ImportState.PREVIEW:
         return st.importPreviewTitle || 'Import Preview';
       case ImportState.IMPORTING:
@@ -421,10 +440,28 @@ function ImportPreviewDialog({ open, importHook, onClose, onNavigateToTab }) {
     </>
   );
 
+  const renderColumnMapping = () => {
+    if (!externalCSVData) return null;
+
+    return (
+      <DialogContent dividers>
+        <ColumnMappingStep
+          headers={externalCSVData.headers}
+          sampleRows={externalCSVData.sampleRows}
+          detectionResult={externalCSVData.detectionResult}
+          onConfirm={handleColumnMappingConfirm}
+          onBack={handleColumnMappingBack}
+        />
+      </DialogContent>
+    );
+  };
+
   const renderContent = () => {
     switch (state) {
       case ImportState.PARSING:
         return renderParsing();
+      case ImportState.COLUMN_MAPPING:
+        return renderColumnMapping();
       case ImportState.PREVIEW:
         return (
           <>

--- a/src/components/ImportPreviewDialog.test.jsx
+++ b/src/components/ImportPreviewDialog.test.jsx
@@ -22,6 +22,7 @@ vi.mock('../hooks/useImportExport', () => ({
   ImportState: {
     IDLE: 'idle',
     PARSING: 'parsing',
+    COLUMN_MAPPING: 'column_mapping',
     PREVIEW: 'preview',
     IMPORTING: 'importing',
     SUCCESS: 'success',
@@ -34,6 +35,16 @@ vi.mock('../lib/firebase', () => ({
   auth: { currentUser: null },
   isAuthenticated: vi.fn(() => false),
   getCurrentUserId: vi.fn(() => null),
+}));
+
+vi.mock('./ColumnMappingStep', () => ({
+  default: ({ headers, onConfirm, onBack }) => (
+    <div data-testid="column-mapping-step">
+      <span data-testid="mapping-headers">{JSON.stringify(headers)}</span>
+      <button data-testid="mapping-confirm" onClick={() => onConfirm({ date: 0, income: 1 })}>Confirm</button>
+      <button data-testid="mapping-back" onClick={onBack}>Back</button>
+    </div>
+  ),
 }));
 
 import { useLanguage } from '../contexts/useLanguage';
@@ -82,7 +93,10 @@ function createImportHook(overrides = {}) {
     importResult: overrides.importResult || null,
     error: overrides.error || null,
     progress: overrides.progress || { current: 0, total: 0, phase: '' },
+    externalCSVData: overrides.externalCSVData || null,
     executeImport: overrides.executeImport || vi.fn(),
+    confirmMapping: overrides.confirmMapping || vi.fn(),
+    goBackToFileSelect: overrides.goBackToFileSelect || vi.fn(),
     reset: overrides.reset || vi.fn(),
     retry: overrides.retry || vi.fn(),
     parseFile: overrides.parseFile || vi.fn(),
@@ -498,6 +512,88 @@ describe('ImportPreviewDialog', () => {
 
       const radioGroup = screen.getByRole('radiogroup');
       expect(radioGroup).toHaveAttribute('aria-label', 'Import mode');
+    });
+  });
+
+  describe('column mapping state', () => {
+    const externalCSVData = {
+      headers: ['תאריך', 'הכנסה', 'מעשר', 'הופרש'],
+      allRows: [['1/2026', '10000', '1000', '500']],
+      sampleRows: [['1/2026', '10000', '1000', '500']],
+      detectionResult: {
+        mappings: { date: 0, income: 1, maaser: 2, donation: 3 },
+        confidence: { date: 'high', income: 'high', maaser: 'high', donation: 'high' },
+        unmapped: [],
+      },
+    };
+
+    it('should render ColumnMappingStep when state is column_mapping', () => {
+      renderDialog({
+        state: 'column_mapping',
+        externalCSVData,
+      });
+
+      expect(screen.getByTestId('column-mapping-step')).toBeInTheDocument();
+    });
+
+    it('should show Map Columns as dialog title during column mapping', () => {
+      renderDialog(
+        { state: 'column_mapping', externalCSVData },
+        {
+          t: {
+            ...defaultTranslations,
+            settings: {
+              ...defaultTranslations.settings,
+              externalImport: { mapColumns: 'Map Columns' },
+            },
+          },
+        }
+      );
+
+      expect(screen.getByText('Map Columns')).toBeInTheDocument();
+    });
+
+    it('should pass headers to ColumnMappingStep', () => {
+      renderDialog({
+        state: 'column_mapping',
+        externalCSVData,
+      });
+
+      const headersEl = screen.getByTestId('mapping-headers');
+      expect(headersEl.textContent).toContain('תאריך');
+    });
+
+    it('should call confirmMapping when ColumnMappingStep confirms', () => {
+      const confirmMapping = vi.fn();
+      renderDialog({
+        state: 'column_mapping',
+        externalCSVData,
+        confirmMapping,
+      });
+
+      fireEvent.click(screen.getByTestId('mapping-confirm'));
+      expect(confirmMapping).toHaveBeenCalledWith({ date: 0, income: 1 });
+    });
+
+    it('should call goBackToFileSelect when ColumnMappingStep goes back', () => {
+      const goBackToFileSelect = vi.fn();
+      renderDialog({
+        state: 'column_mapping',
+        externalCSVData,
+        goBackToFileSelect,
+      });
+
+      fireEvent.click(screen.getByTestId('mapping-back'));
+      expect(goBackToFileSelect).toHaveBeenCalled();
+    });
+
+    it('should not render ColumnMappingStep when externalCSVData is null', () => {
+      renderDialog({
+        state: 'column_mapping',
+        externalCSVData: null,
+      });
+
+      expect(screen.queryByTestId('column-mapping-step')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/hooks/useImportExport.js
+++ b/src/hooks/useImportExport.js
@@ -5,7 +5,9 @@
  * Connects UI components to exportService and importService.
  *
  * Export hooks read entries via useEntries and trigger file downloads.
- * Import hook manages a state machine: IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR.
+ * Import hook manages a state machine:
+ *   IDLE -> PARSING -> [COLUMN_MAPPING ->] PREVIEW -> IMPORTING -> SUCCESS/ERROR.
+ * External CSVs route through COLUMN_MAPPING; app-format CSVs/JSON skip to PREVIEW.
  * Cache invalidation is performed after every successful import.
  */
 
@@ -17,19 +19,29 @@ import {
   parseJSONFile,
   parseCSVFile,
   importEntries,
+  validateImportEntry,
   IMPORT_MODE_MERGE,
   IMPORT_MODE_REPLACE,
+  stripBOM,
 } from '../services/importService';
+import { detectColumns, transformRows } from '../services/columnMappingService';
 
 /** Import state machine states */
 export const ImportState = {
   IDLE: 'idle',
   PARSING: 'parsing',
+  COLUMN_MAPPING: 'column_mapping',
   PREVIEW: 'preview',
   IMPORTING: 'importing',
   SUCCESS: 'success',
   ERROR: 'error',
 };
+
+/**
+ * App's own CSV column headers — used to detect whether a CSV was exported
+ * by Ma'aser Tracker (app format) vs. an external spreadsheet.
+ */
+const APP_CSV_HEADERS = ['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth'];
 
 /**
  * Hook for exporting entries as JSON.
@@ -112,10 +124,26 @@ export function useExportCSV() {
 }
 
 /**
+ * Check whether CSV headers match the app's own export format.
+ * All 7 required headers must be present (order-independent).
+ *
+ * @param {string[]} headers - Parsed CSV header row
+ * @returns {boolean} true if the CSV is in app format
+ */
+export function isAppCSVFormat(headers) {
+  if (!Array.isArray(headers) || headers.length === 0) return false;
+  const normalized = headers.map((h) => (h || '').trim().toLowerCase());
+  return APP_CSV_HEADERS.every((expected) => normalized.includes(expected.toLowerCase()));
+}
+
+/**
  * Hook for importing entries from a file.
  *
  * Manages the import state machine:
- *   IDLE -> PARSING -> PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ *   IDLE -> PARSING -> [COLUMN_MAPPING ->] PREVIEW -> IMPORTING -> SUCCESS/ERROR
+ *
+ * External CSVs route through COLUMN_MAPPING for user-driven column mapping.
+ * App-format CSVs and JSON files skip directly to PREVIEW.
  *
  * @returns {Object} Import state and control functions
  */
@@ -128,8 +156,14 @@ export function useImport() {
   const [progress, setProgress] = useState({ current: 0, total: 0, phase: '' });
   const fileRef = useRef(null);
 
+  // External CSV column mapping data (populated for external CSVs)
+  const [externalCSVData, setExternalCSVData] = useState(null);
+
   /**
-   * Parse a file and transition to PREVIEW state.
+   * Parse a file and transition to PREVIEW or COLUMN_MAPPING state.
+   * - JSON files: always go to PREVIEW (existing behavior)
+   * - CSV files in app format: go to PREVIEW (existing behavior)
+   * - CSV files in external format: go to COLUMN_MAPPING
    * @param {File} file - File to parse
    */
   const parseFile = useCallback(async (file) => {
@@ -140,31 +174,159 @@ export function useImport() {
     setError(null);
     setParseResult(null);
     setImportResult(null);
+    setExternalCSVData(null);
 
     try {
       const isCSV = file.name.toLowerCase().endsWith('.csv');
-      const result = isCSV ? await parseCSVFile(file) : await parseJSONFile(file);
 
-      // If there are file-level errors AND no valid entries, treat as error
-      if (result.validEntries.length === 0 && result.errors.length > 0) {
-        setState(ImportState.ERROR);
-        setError(result.errors[0]);
-        return;
+      if (isCSV) {
+        // Read file text and parse with PapaParse to inspect headers
+        let text = await file.text();
+        text = stripBOM(text);
+
+        let Papa;
+        try {
+          const module = await import('papaparse');
+          Papa = module.default || module;
+        } catch {
+          setState(ImportState.ERROR);
+          setError('Failed to load CSV parser');
+          return;
+        }
+
+        const rawParse = Papa.parse(text, {
+          header: false,
+          skipEmptyLines: true,
+          dynamicTyping: false,
+          delimiter: '',
+        });
+
+        if (!rawParse.data || rawParse.data.length < 2) {
+          setState(ImportState.ERROR);
+          setError('No data rows found in CSV');
+          return;
+        }
+
+        const headers = rawParse.data[0];
+        const dataRows = rawParse.data.slice(1);
+
+        if (isAppCSVFormat(headers)) {
+          // App format — use existing parseCSVFile pipeline
+          const result = await parseCSVFile(file);
+
+          if (result.validEntries.length === 0 && result.errors.length > 0) {
+            setState(ImportState.ERROR);
+            setError(result.errors[0]);
+            return;
+          }
+
+          setParseResult({
+            filename: file.name,
+            fileSize: file.size,
+            validEntries: result.validEntries,
+            invalidEntries: result.invalidEntries,
+            warnings: result.warnings,
+            errors: result.errors,
+          });
+          setState(ImportState.PREVIEW);
+        } else {
+          // External CSV — route to column mapping
+          const detection = detectColumns(headers);
+
+          setExternalCSVData({
+            headers,
+            allRows: dataRows,
+            sampleRows: dataRows.slice(0, 5),
+            detectionResult: detection,
+          });
+          setState(ImportState.COLUMN_MAPPING);
+        }
+      } else {
+        // JSON file — existing behavior
+        const result = await parseJSONFile(file);
+
+        if (result.validEntries.length === 0 && result.errors.length > 0) {
+          setState(ImportState.ERROR);
+          setError(result.errors[0]);
+          return;
+        }
+
+        setParseResult({
+          filename: file.name,
+          fileSize: file.size,
+          validEntries: result.validEntries,
+          invalidEntries: result.invalidEntries,
+          warnings: result.warnings,
+          errors: result.errors,
+        });
+        setState(ImportState.PREVIEW);
       }
-
-      setParseResult({
-        filename: file.name,
-        fileSize: file.size,
-        validEntries: result.validEntries,
-        invalidEntries: result.invalidEntries,
-        warnings: result.warnings,
-        errors: result.errors,
-      });
-      setState(ImportState.PREVIEW);
     } catch (err) {
       setState(ImportState.ERROR);
       setError(err.message || 'Failed to parse file');
     }
+  }, []);
+
+  /**
+   * Confirm column mapping and transform external CSV rows into app entries.
+   * Transitions from COLUMN_MAPPING to PREVIEW.
+   *
+   * @param {Record<string, number>} finalMappings - User-confirmed column mappings
+   */
+  const confirmMapping = useCallback((finalMappings) => {
+    if (!externalCSVData) return;
+
+    const { allRows } = externalCSVData;
+    const { entries, skippedRows, stats } = transformRows(allRows, finalMappings);
+
+    // Validate each transformed entry through the import pipeline
+    const validEntries = [];
+    const invalidEntries = [];
+    const errors = [];
+
+    for (let i = 0; i < entries.length; i++) {
+      const result = validateImportEntry(entries[i], { external: true });
+      if (result.valid) {
+        validEntries.push(result.entry);
+      } else {
+        invalidEntries.push({ index: i, raw: entries[i], errors: result.errors });
+        errors.push(`Entry ${i + 1}: ${result.errors.join(', ')}`);
+      }
+    }
+
+    // Add skipped-row info to errors for visibility
+    const warnings = [];
+    if (skippedRows.length > 0) {
+      warnings.push(
+        `${skippedRows.length} rows skipped: ${skippedRows.slice(0, 3).map((s) => `row ${s.row} (${s.reason})`).join(', ')}${skippedRows.length > 3 ? '...' : ''}`
+      );
+    }
+
+    if (validEntries.length === 0) {
+      setState(ImportState.ERROR);
+      setError(errors[0] || 'No valid entries after column mapping');
+      return;
+    }
+
+    setParseResult({
+      filename: fileRef.current?.name || 'external.csv',
+      fileSize: fileRef.current?.size || 0,
+      validEntries,
+      invalidEntries,
+      warnings,
+      errors,
+      externalImportStats: stats,
+    });
+    setState(ImportState.PREVIEW);
+  }, [externalCSVData]);
+
+  /**
+   * Go back from COLUMN_MAPPING to IDLE (file select).
+   */
+  const goBackToFileSelect = useCallback(() => {
+    setState(ImportState.IDLE);
+    setExternalCSVData(null);
+    fileRef.current = null;
   }, []);
 
   /**
@@ -213,6 +375,7 @@ export function useImport() {
     setImportResult(null);
     setError(null);
     setProgress({ current: 0, total: 0, phase: '' });
+    setExternalCSVData(null);
     fileRef.current = null;
   }, []);
 
@@ -231,7 +394,10 @@ export function useImport() {
     importResult,
     error,
     progress,
+    externalCSVData,
     parseFile,
+    confirmMapping,
+    goBackToFileSelect,
     executeImport,
     reset,
     retry,

--- a/src/hooks/useImportExport.test.jsx
+++ b/src/hooks/useImportExport.test.jsx
@@ -2,6 +2,7 @@
  * useImportExport Hook Tests
  *
  * Tests for useExportJSON, useExportCSV, and useImport hooks.
+ * Includes tests for external CSV detection and column mapping flow.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -20,8 +21,15 @@ vi.mock('../services/importService', () => ({
   parseJSONFile: vi.fn(),
   parseCSVFile: vi.fn(),
   importEntries: vi.fn(),
+  validateImportEntry: vi.fn(),
+  stripBOM: vi.fn((text) => text),
   IMPORT_MODE_MERGE: 'merge',
   IMPORT_MODE_REPLACE: 'replace',
+}));
+
+vi.mock('../services/columnMappingService', () => ({
+  detectColumns: vi.fn(),
+  transformRows: vi.fn(),
 }));
 
 vi.mock('./useEntries', () => ({
@@ -44,9 +52,18 @@ vi.mock('../lib/firebase', () => ({
   getCurrentUserId: vi.fn(() => null),
 }));
 
-import { useExportJSON, useExportCSV, useImport, ImportState } from './useImportExport';
+// Mock PapaParse as dynamic import — the hook does `import('papaparse')` at runtime
+const mockPapaParse = {
+  parse: vi.fn(),
+};
+vi.mock('papaparse', () => ({
+  default: { parse: (...args) => mockPapaParse.parse(...args) },
+}));
+
+import { useExportJSON, useExportCSV, useImport, ImportState, isAppCSVFormat } from './useImportExport';
 import { exportToJSON, exportToCSV, downloadFile, generateFilename } from '../services/exportService';
-import { parseJSONFile, parseCSVFile, importEntries } from '../services/importService';
+import { parseJSONFile, parseCSVFile, importEntries, validateImportEntry } from '../services/importService';
+import { detectColumns, transformRows } from '../services/columnMappingService';
 import { useEntries } from './useEntries';
 
 function createWrapper() {
@@ -236,7 +253,17 @@ describe('useImport', () => {
     expect(result.current.parseResult.filename).toBe('data.json');
   });
 
-  it('should parse a CSV file and transition to PREVIEW', async () => {
+  it('should parse an app-format CSV file and transition to PREVIEW', async () => {
+    // Mock PapaParse to return app-format headers
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth'],
+        ['abc-123', 'income', '2026-01-15', '5000', '500', 'Salary', '2026-01'],
+      ],
+      errors: [],
+      meta: { fields: [] },
+    });
+
     parseCSVFile.mockResolvedValue({
       validEntries: [{ type: 'income', date: '2026-01-15', amount: 5000 }],
       invalidEntries: [],
@@ -246,7 +273,8 @@ describe('useImport', () => {
 
     const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
 
-    const mockFile = new File([''], 'data.csv', { type: 'text/csv' });
+    const csvContent = 'id,type,date,amount,maaser,note,accountingMonth\nabc-123,income,2026-01-15,5000,500,Salary,2026-01';
+    const mockFile = new File([csvContent], 'data.csv', { type: 'text/csv' });
 
     await act(async () => {
       await result.current.parseFile(mockFile);
@@ -518,5 +546,422 @@ describe('useImport', () => {
     expect(result.current.parseResult.fileSize).toBe(1000);
     expect(result.current.parseResult.invalidEntries).toHaveLength(1);
     expect(result.current.parseResult.warnings).toContain('File is large');
+  });
+
+  it('should have COLUMN_MAPPING in ImportState', () => {
+    expect(ImportState.COLUMN_MAPPING).toBe('column_mapping');
+  });
+
+  it('should expose externalCSVData as null initially', () => {
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+    expect(result.current.externalCSVData).toBeNull();
+  });
+});
+
+describe('isAppCSVFormat', () => {
+  it('should return true for exact app headers', () => {
+    expect(isAppCSVFormat(['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth'])).toBe(true);
+  });
+
+  it('should return true for app headers in different order', () => {
+    expect(isAppCSVFormat(['date', 'type', 'id', 'amount', 'accountingMonth', 'note', 'maaser'])).toBe(true);
+  });
+
+  it('should return true for app headers with extra columns', () => {
+    expect(isAppCSVFormat(['id', 'type', 'date', 'amount', 'maaser', 'note', 'accountingMonth', 'extra'])).toBe(true);
+  });
+
+  it('should return true regardless of case', () => {
+    expect(isAppCSVFormat(['ID', 'Type', 'Date', 'Amount', 'Maaser', 'Note', 'AccountingMonth'])).toBe(true);
+  });
+
+  it('should return false for external CSV headers', () => {
+    expect(isAppCSVFormat(['תאריך', 'הכנסה', 'מעשר', 'הופרש'])).toBe(false);
+  });
+
+  it('should return false when missing required headers', () => {
+    expect(isAppCSVFormat(['date', 'amount', 'note'])).toBe(false);
+  });
+
+  it('should return false for empty array', () => {
+    expect(isAppCSVFormat([])).toBe(false);
+  });
+
+  it('should return false for null/undefined', () => {
+    expect(isAppCSVFormat(null)).toBe(false);
+    expect(isAppCSVFormat(undefined)).toBe(false);
+  });
+
+  it('should handle headers with whitespace', () => {
+    expect(isAppCSVFormat([' id ', ' type ', ' date ', ' amount ', ' maaser ', ' note ', ' accountingMonth '])).toBe(true);
+  });
+});
+
+describe('useImport — external CSV flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should route external CSV to COLUMN_MAPPING state', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['תאריך', 'הכנסה', 'מעשר', 'הופרש'],
+        ['1/2026', '10000', '1000', '500'],
+        ['2/2026', '12000', '1200', '600'],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1, maaser: 2, donation: 3 },
+      confidence: { date: 'high', income: 'high', maaser: 'high', donation: 'high' },
+      unmapped: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const csvContent = 'תאריך,הכנסה,מעשר,הופרש\n1/2026,10000,1000,500\n2/2026,12000,1200,600';
+    const mockFile = new File([csvContent], 'maaser-sheet.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.COLUMN_MAPPING);
+    expect(result.current.externalCSVData).not.toBeNull();
+    expect(result.current.externalCSVData.headers).toEqual(['תאריך', 'הכנסה', 'מעשר', 'הופרש']);
+    expect(result.current.externalCSVData.allRows).toHaveLength(2);
+    expect(result.current.externalCSVData.sampleRows).toHaveLength(2);
+    expect(result.current.externalCSVData.detectionResult.mappings.date).toBe(0);
+    expect(detectColumns).toHaveBeenCalledWith(['תאריך', 'הכנסה', 'מעשר', 'הופרש']);
+  });
+
+  it('should limit sampleRows to first 5', async () => {
+    const rows = Array.from({ length: 10 }, (_, i) => [`${i + 1}/2026`, `${(i + 1) * 1000}`, '100', '50']);
+    mockPapaParse.parse.mockReturnValue({
+      data: [['date', 'income', 'donation', 'tithe'], ...rows],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1, donation: 2, maaser: 3 },
+      confidence: {},
+      unmapped: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv content'], 'big.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.externalCSVData.allRows).toHaveLength(10);
+    expect(result.current.externalCSVData.sampleRows).toHaveLength(5);
+  });
+
+  it('should transition to ERROR when CSV has no data rows', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [['header1']],
+      errors: [],
+      meta: {},
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['header1'], 'empty.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('No data rows found in CSV');
+  });
+
+  it('should confirm mapping and transition to PREVIEW', async () => {
+    // Setup: get to COLUMN_MAPPING state
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['תאריך', 'הכנסה', 'מעשר', 'הופרש'],
+        ['1/2026', '10000', '1000', '500'],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1, maaser: 2, donation: 3 },
+      confidence: { date: 'high', income: 'high', maaser: 'high', donation: 'high' },
+      unmapped: [],
+    });
+
+    transformRows.mockReturnValue({
+      entries: [
+        { id: 'uuid-1', type: 'income', date: '2026-01-01', amount: 10000, maaser: 1000, accountingMonth: '2026-01', note: '' },
+        { id: 'uuid-2', type: 'donation', date: '2026-01-01', amount: 500, accountingMonth: '2026-01', note: '' },
+      ],
+      skippedRows: [],
+      stats: { totalRows: 1, incomeEntries: 1, donationEntries: 1, skipped: 0 },
+    });
+
+    validateImportEntry.mockImplementation((entry) => ({
+      valid: true,
+      entry,
+      errors: [],
+    }));
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv content'], 'maaser.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.COLUMN_MAPPING);
+
+    // Confirm mapping
+    act(() => {
+      result.current.confirmMapping({ date: 0, income: 1, maaser: 2, donation: 3 });
+    });
+
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+    expect(result.current.parseResult.validEntries).toHaveLength(2);
+    expect(result.current.parseResult.filename).toBe('maaser.csv');
+    expect(result.current.parseResult.externalImportStats).toBeDefined();
+    expect(transformRows).toHaveBeenCalledWith(
+      [['1/2026', '10000', '1000', '500']],
+      { date: 0, income: 1, maaser: 2, donation: 3 }
+    );
+  });
+
+  it('should add skipped row warnings to parse result', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['date', 'income'],
+        ['1/2026', '10000'],
+        ['bad', ''],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1 },
+      confidence: {},
+      unmapped: [],
+    });
+
+    transformRows.mockReturnValue({
+      entries: [
+        { id: 'uuid-1', type: 'income', date: '2026-01-01', amount: 10000, accountingMonth: '2026-01', note: '' },
+      ],
+      skippedRows: [{ row: 2, reason: 'Invalid or missing date' }],
+      stats: { totalRows: 2, incomeEntries: 1, donationEntries: 0, skipped: 1 },
+    });
+
+    validateImportEntry.mockImplementation((entry) => ({
+      valid: true,
+      entry,
+      errors: [],
+    }));
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv'], 'data.csv', { type: 'text/csv' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    act(() => {
+      result.current.confirmMapping({ date: 0, income: 1 });
+    });
+
+    expect(result.current.parseResult.warnings).toHaveLength(1);
+    expect(result.current.parseResult.warnings[0]).toContain('1 rows skipped');
+  });
+
+  it('should transition to ERROR if no valid entries after mapping', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['date', 'income'],
+        ['bad', ''],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1 },
+      confidence: {},
+      unmapped: [],
+    });
+
+    transformRows.mockReturnValue({
+      entries: [],
+      skippedRows: [{ row: 1, reason: 'Invalid or missing date' }],
+      stats: { totalRows: 1, incomeEntries: 0, donationEntries: 0, skipped: 1 },
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv'], 'bad.csv', { type: 'text/csv' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    act(() => {
+      result.current.confirmMapping({ date: 0, income: 1 });
+    });
+
+    expect(result.current.state).toBe(ImportState.ERROR);
+    expect(result.current.error).toBe('No valid entries after column mapping');
+  });
+
+  it('should go back to IDLE from COLUMN_MAPPING via goBackToFileSelect', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['date', 'income'],
+        ['1/2026', '10000'],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1 },
+      confidence: {},
+      unmapped: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv'], 'data.csv', { type: 'text/csv' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.state).toBe(ImportState.COLUMN_MAPPING);
+
+    act(() => {
+      result.current.goBackToFileSelect();
+    });
+
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(result.current.externalCSVData).toBeNull();
+  });
+
+  it('should reset clears externalCSVData', async () => {
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['date', 'income'],
+        ['1/2026', '10000'],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1 },
+      confidence: {},
+      unmapped: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv'], 'data.csv', { type: 'text/csv' });
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+
+    expect(result.current.externalCSVData).not.toBeNull();
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state).toBe(ImportState.IDLE);
+    expect(result.current.externalCSVData).toBeNull();
+  });
+
+  it('should not confirm mapping when externalCSVData is null', () => {
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.confirmMapping({ date: 0, income: 1 });
+    });
+
+    // Should remain in IDLE, no error thrown
+    expect(result.current.state).toBe(ImportState.IDLE);
+  });
+
+  it('should complete full external CSV flow: parse -> map -> preview -> import', async () => {
+    // Step 1: Parse external CSV
+    mockPapaParse.parse.mockReturnValue({
+      data: [
+        ['תאריך', 'הכנסה', 'מעשר', 'הופרש'],
+        ['1/2026', '10000', '1000', '500'],
+      ],
+      errors: [],
+      meta: {},
+    });
+
+    detectColumns.mockReturnValue({
+      mappings: { date: 0, income: 1, maaser: 2, donation: 3 },
+      confidence: { date: 'high', income: 'high', maaser: 'high', donation: 'high' },
+      unmapped: [],
+    });
+
+    transformRows.mockReturnValue({
+      entries: [
+        { id: 'uuid-1', type: 'income', date: '2026-01-01', amount: 10000, maaser: 1000, accountingMonth: '2026-01', note: '' },
+        { id: 'uuid-2', type: 'donation', date: '2026-01-01', amount: 500, accountingMonth: '2026-01', note: '' },
+      ],
+      skippedRows: [],
+      stats: { totalRows: 1, incomeEntries: 1, donationEntries: 1, skipped: 0 },
+    });
+
+    validateImportEntry.mockImplementation((entry) => ({
+      valid: true,
+      entry,
+      errors: [],
+    }));
+
+    importEntries.mockResolvedValue({
+      success: true,
+      mode: 'merge',
+      imported: 2,
+      backedUp: 0,
+      failed: [],
+      errors: [],
+    });
+
+    const { result } = renderHook(() => useImport(), { wrapper: createWrapper() });
+
+    const mockFile = new File(['csv'], 'maaser.csv', { type: 'text/csv' });
+
+    // Parse -> COLUMN_MAPPING
+    await act(async () => {
+      await result.current.parseFile(mockFile);
+    });
+    expect(result.current.state).toBe(ImportState.COLUMN_MAPPING);
+
+    // Confirm mapping -> PREVIEW
+    act(() => {
+      result.current.confirmMapping({ date: 0, income: 1, maaser: 2, donation: 3 });
+    });
+    expect(result.current.state).toBe(ImportState.PREVIEW);
+    expect(result.current.parseResult.validEntries).toHaveLength(2);
+
+    // Execute import -> SUCCESS
+    await act(async () => {
+      await result.current.executeImport('merge');
+    });
+    expect(result.current.state).toBe(ImportState.SUCCESS);
+    expect(result.current.importResult.imported).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
Add COLUMN_MAPPING state to the import flow. Wire ColumnMappingStep into ImportPreviewDialog. External CSVs go through column mapping before preview; app's own format skips to preview directly.

### What changed
- **`useImportExport.js`** — New `COLUMN_MAPPING` state in state machine. `isAppCSVFormat()` detects app vs external CSV by comparing headers against `['id','type','date','amount','maaser','note','accountingMonth']`. External CSVs parsed with PapaParse, headers passed to `detectColumns()`, data stored in `externalCSVData`. New `confirmMapping()` transforms rows via `transformRows()` + validates via `validateImportEntry({ external: true })` then transitions to PREVIEW. New `goBackToFileSelect()` returns to IDLE.
- **`ImportPreviewDialog.jsx`** — Renders `<ColumnMappingStep>` when state is `COLUMN_MAPPING`. Dialog title shows "Map Columns" during mapping. Confirm/back handlers wired.
- **`useImportExport.test.jsx`** — 22 new tests: `isAppCSVFormat` (9 cases), external CSV routing (4), column mapping confirm/back (5), end-to-end flow (2), edge cases (2).
- **`ImportPreviewDialog.test.jsx`** — 6 new tests for COLUMN_MAPPING rendering, header passthrough, confirm/back delegation, null externalCSVData guard.

### State machine
```
IDLE → PARSING → is app CSV? → YES → PREVIEW → IMPORTING → SUCCESS/ERROR
                             → NO  → COLUMN_MAPPING → PREVIEW → IMPORTING → SUCCESS/ERROR
```

Closes #146
Part of epic #142