### PR TITLE
#169 Auth API Fix — Replace _tokenResponse with getAdditionalUserInfo (SA-01)

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -16,6 +16,7 @@ import {
   signInWithPopup,
   signOut as firebaseSignOut,
   onAuthStateChanged as firebaseOnAuthStateChanged,
+  getAdditionalUserInfo,
 } from 'firebase/auth';
 import { auth } from '../lib/firebase';
 
@@ -48,7 +49,7 @@ export async function signInWithGoogle() {
     const user = result.user;
 
     // Check if this is a new user (first sign-in)
-    const isNewUser = result._tokenResponse?.isNewUser ?? false;
+    const isNewUser = getAdditionalUserInfo(result)?.isNewUser ?? false;
 
     return {
       user: {

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -18,6 +18,7 @@ vi.mock('firebase/auth', () => {
     signInWithPopup: vi.fn(),
     signOut: vi.fn(),
     onAuthStateChanged: vi.fn(),
+    getAdditionalUserInfo: vi.fn(),
   };
 });
 
@@ -38,6 +39,7 @@ import {
   signInWithPopup,
   signOut as firebaseSignOut,
   onAuthStateChanged as firebaseOnAuthStateChanged,
+  getAdditionalUserInfo,
 } from 'firebase/auth';
 import { auth } from '../lib/firebase';
 
@@ -57,13 +59,13 @@ describe('auth service', () => {
         photoURL: 'https://example.com/photo.jpg',
       };
 
-      signInWithPopup.mockResolvedValueOnce({
-        user: mockUser,
-        _tokenResponse: { isNewUser: false },
-      });
+      const mockResult = { user: mockUser };
+      signInWithPopup.mockResolvedValueOnce(mockResult);
+      getAdditionalUserInfo.mockReturnValueOnce({ isNewUser: false });
 
       const result = await signInWithGoogle();
 
+      expect(getAdditionalUserInfo).toHaveBeenCalledWith(mockResult);
       expect(result.user).toEqual({
         uid: 'test-uid-123',
         email: 'test@example.com',
@@ -81,14 +83,28 @@ describe('auth service', () => {
         photoURL: null,
       };
 
-      signInWithPopup.mockResolvedValueOnce({
-        user: mockUser,
-        _tokenResponse: { isNewUser: true },
-      });
+      signInWithPopup.mockResolvedValueOnce({ user: mockUser });
+      getAdditionalUserInfo.mockReturnValueOnce({ isNewUser: true });
 
       const result = await signInWithGoogle();
 
       expect(result.isNewUser).toBe(true);
+    });
+
+    it('should default isNewUser to false when getAdditionalUserInfo returns null', async () => {
+      const mockUser = {
+        uid: 'edge-user-123',
+        email: 'edge@example.com',
+        displayName: 'Edge User',
+        photoURL: null,
+      };
+
+      signInWithPopup.mockResolvedValueOnce({ user: mockUser });
+      getAdditionalUserInfo.mockReturnValueOnce(null);
+
+      const result = await signInWithGoogle();
+
+      expect(result.isNewUser).toBe(false);
     });
 
     it('should handle popup closed by user', async () => {


### PR DESCRIPTION
Closes #169

## Summary
Replace internal `_tokenResponse.isNewUser` with the public `getAdditionalUserInfo(result)?.isNewUser` API from `firebase/auth`. This fixes security audit finding SA-01 — using undocumented internal API properties that could break without notice.

## Changes
- Import `getAdditionalUserInfo` from `firebase/auth`
- Replace `result._tokenResponse?.isNewUser` with `getAdditionalUserInfo(result)?.isNewUser`
- Update tests to mock `getAdditionalUserInfo` instead of `_tokenResponse`
- Add edge case test for `getAdditionalUserInfo` returning `null`

## Checklist
- [x] Tests passing (19/19 auth tests, 2061/2061 full suite)
- [x] Lint clean (0 errors, 0 warnings)
- [x] Code review (syntax + security)
- [x] CI green