### PR TITLE
#171 PWA Cache Fix — Remove opaque response caching (SA-10)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -75,7 +75,7 @@ export default defineConfig({
                 maxAgeSeconds: 60 * 60 * 24 * 365,
               },
               cacheableResponse: {
-                statuses: [0, 200],
+                statuses: [200],
               },
             },
           },
@@ -89,7 +89,7 @@ export default defineConfig({
                 maxAgeSeconds: 60 * 60 * 24 * 365,
               },
               cacheableResponse: {
-                statuses: [0, 200],
+                statuses: [200],
               },
             },
           },


### PR DESCRIPTION
Closes #171

## Summary
Remove opaque response (status 0) from PWA runtime caching configuration to prevent caching potentially errored cross-origin responses (SA-10).

## Changes
- `vite.config.js`: Change `statuses: [0, 200]` to `statuses: [200]` in both Google Fonts and gstatic runtime caching entries

## Checklist
- [x] Tests passing (2060/2060, 1 pre-existing flaky timeout)
- [x] Lint clean (0 errors, 0 warnings)
- [x] Build succeeds (SW generated correctly)
- [x] CI green