### PR TITLE
#170 Dependency Vulnerability Tracking (SA-07)

### DIFF
--- a/docs/DEPENDENCY_VULNERABILITY_TRACKING.md
+++ b/docs/DEPENDENCY_VULNERABILITY_TRACKING.md
@@ -1,0 +1,146 @@
+# Dependency Vulnerability Tracking
+
+**Created:** 2026-03-12
+**Last Reviewed:** 2026-03-12
+**Issue:** #170 (SA-07)
+**Severity:** HIGH
+**Status:** Monitoring
+
+---
+
+## SA-07: serialize-javascript RCE Vulnerability
+
+### Summary
+
+The `serialize-javascript` package (versions <=7.0.2) is vulnerable to Remote Code
+Execution (RCE) via `RegExp.flags` and `Date.prototype.toISOString()`.
+
+Advisory: https://github.com/advisories/GHSA-5c6j-r48x-rmvq
+
+### Dependency Chain
+
+```
+vite-plugin-pwa (>=0.20.0)
+  -> workbox-build (>=7.1.0)
+    -> @rollup/plugin-terser (0.2.0 - 0.4.4)
+      -> serialize-javascript (<=7.0.2)   <-- VULNERABLE
+```
+
+All four packages in the chain report as HIGH severity in `npm audit`.
+
+### Risk Assessment
+
+| Factor | Detail |
+|--------|--------|
+| **Exploitability** | Build-time only. The vulnerable code runs during the Vite build process (minification via Terser), NOT at runtime in the browser. |
+| **Runtime Impact** | None. `serialize-javascript` is not bundled into the production application. It is a devDependency transitive. |
+| **Attack Vector** | An attacker would need to inject malicious code into the build pipeline (e.g., supply-chain attack on source code or CI environment). |
+| **End-User Risk** | No direct risk to end users. The vulnerability cannot be triggered by user interaction with the deployed application. |
+| **CI/CD Risk** | LOW. The build runs in a sandboxed GitHub Actions environment with no access to production secrets beyond deployment tokens. |
+
+**Conclusion:** This is a build-chain-only vulnerability with no runtime exposure. The risk
+is limited to supply-chain attack scenarios against the build process itself. While it
+should be resolved, it does not pose an immediate threat to users or production data.
+
+### Current npm audit Output (2026-03-12)
+
+```
+# npm audit report
+
+serialize-javascript  <=7.0.2
+Severity: high
+Serialize JavaScript is Vulnerable to RCE via RegExp.flags
+  and Date.prototype.toISOString()
+  https://github.com/advisories/GHSA-5c6j-r48x-rmvq
+fix available via `npm audit fix --force`
+Will install vite-plugin-pwa@0.19.8, which is a breaking change
+node_modules/serialize-javascript
+  @rollup/plugin-terser  0.2.0 - 0.4.4
+  node_modules/@rollup/plugin-terser
+    workbox-build  >=7.1.0
+    node_modules/workbox-build
+      vite-plugin-pwa  >=0.20.0
+      node_modules/vite-plugin-pwa
+
+4 high severity vulnerabilities
+```
+
+---
+
+## Action Plan
+
+### Option A: Wait for Upstream Fix (Preferred)
+
+**Timeline:** Check weekly, deadline 2026-04-12 (30 days)
+
+The cleanest resolution is for one of the upstream packages to update its dependency:
+- `@rollup/plugin-terser` releases a version that depends on `serialize-javascript >7.0.2`
+- `workbox-build` updates its `@rollup/plugin-terser` dependency
+- `vite-plugin-pwa` updates its `workbox-build` dependency
+
+**Weekly Check Process:**
+1. Run `npm audit` to see if the vulnerability is still present
+2. Run `npm outdated vite-plugin-pwa workbox-build` to check for new versions
+3. Check the following repositories for relevant PRs/releases:
+   - https://github.com/nicolo-ribaudo/serialize-javascript
+   - https://github.com/nicolo-ribaudo/rollup-plugin-terser (or @rollup/plugin-terser)
+   - https://github.com/nicolo-ribaudo/workbox
+   - https://github.com/vite-pwa/vite-plugin-pwa
+4. Update this document with findings
+
+### Option B: Downgrade vite-plugin-pwa to 0.19.8
+
+**Timeline:** If Option A yields no fix by 2026-04-12
+
+`npm audit fix --force` will install `vite-plugin-pwa@0.19.8`, which resolves the
+vulnerability but is a breaking change from the current version (>=0.20.0).
+
+**Risks:**
+- Potential breaking changes in PWA configuration
+- Loss of features added in 0.20.0+
+- Requires testing of all PWA functionality (install prompt, service worker, offline mode)
+
+**Steps if needed:**
+1. Create a feature branch
+2. Run `npm audit fix --force`
+3. Verify PWA configuration still works (`vite.config.js` PWA section)
+4. Run full test suite
+5. Test PWA install flow manually on mobile and desktop
+6. Test offline mode
+7. Submit for review
+
+### Option C: npm Overrides
+
+**Timeline:** If a patched `serialize-javascript` is released but upstream hasn't adopted it
+
+Add to `package.json`:
+```json
+{
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
+  }
+}
+```
+
+**Risks:**
+- May cause incompatibilities if the API changed
+- Requires testing to verify Terser/Workbox still functions correctly
+- Override must be removed once upstream catches up
+
+---
+
+## Review Log
+
+| Date | Reviewer | Finding | Action |
+|------|----------|---------|--------|
+| 2026-03-12 | Initial audit | Vulnerability confirmed, build-time only | Created tracking document |
+
+---
+
+## References
+
+- [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) - Advisory
+- [serialize-javascript npm](https://www.npmjs.com/package/serialize-javascript) - Package
+- [vite-plugin-pwa](https://github.com/vite-pwa/vite-plugin-pwa) - Root dependency
+- [Issue #140](https://github.com/DubiWork/maaser-tracker/issues/140) - Parent security audit
+- [Issue #170](https://github.com/DubiWork/maaser-tracker/issues/170) - This tracking issue


### PR DESCRIPTION
Closes #170

## Summary
Document and track the serialize-javascript RCE vulnerability (SA-07) found in the build-chain transitive dependency:
`vite-plugin-pwa -> workbox-build -> @rollup/plugin-terser -> serialize-javascript`

This is a documentation-only change that establishes a tracking process for this build-time vulnerability.

### Key findings
- Vulnerability is **build-time only** -- serialize-javascript is NOT bundled into production
- No runtime risk to end users
- Three remediation options documented with a 30-day deadline (2026-04-12)

## Checklist
- [x] Tests passing (2059 pass, 2 pre-existing flaky timeouts unrelated to this change)
- [x] Lint clean (0 errors, 0 warnings)
- [x] No code changes (documentation only)
- [x] CI green