### PR TITLE
#175 HTTP Security Headers + CSP (SA-14)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,20 @@
       ],
       "headers": [
         {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
+            { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+            {
+              "key": "Content-Security-Policy",
+              "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.googleusercontent.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com wss://*.firebaseio.com; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+            }
+          ]
+        },
+        {
           "source": "**/*.@(jpg|jpeg|gif|png|svg|webp|ico)",
           "headers": [
             {
@@ -62,6 +76,20 @@
         }
       ],
       "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+            { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
+            { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+            {
+              "key": "Content-Security-Policy",
+              "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.googleusercontent.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com wss://*.firebaseio.com; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+            }
+          ]
+        },
         {
           "source": "**/*.@(jpg|jpeg|gif|png|svg|webp|ico)",
           "headers": [

--- a/src/lib/firebaseHosting.test.js
+++ b/src/lib/firebaseHosting.test.js
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Static analysis tests for firebase.json hosting configuration.
+ * Verifies that HTTP security headers and CSP are present on both
+ * hosting targets (production and staging).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REQUIRED_SECURITY_HEADERS = [
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy' },
+  { key: 'Strict-Transport-Security' },
+  { key: 'Content-Security-Policy' },
+];
+
+const CSP_REQUIRED_DIRECTIVES = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' https://fonts.gstatic.com",
+  "img-src 'self' data: https://*.googleusercontent.com",
+  "connect-src 'self'",
+  "worker-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+];
+
+describe('Firebase Hosting Security Headers', () => {
+  let config;
+  let hostingTargets;
+
+  beforeAll(() => {
+    const filePath = resolve(__dirname, '../../firebase.json');
+    const raw = readFileSync(filePath, 'utf-8');
+    config = JSON.parse(raw);
+    hostingTargets = config.hosting;
+  });
+
+  it('should have valid firebase.json with hosting array', () => {
+    expect(config).toBeDefined();
+    expect(Array.isArray(hostingTargets)).toBe(true);
+    expect(hostingTargets.length).toBeGreaterThanOrEqual(2);
+  });
+
+  describe.each([
+    ['production'],
+    ['staging'],
+  ])('%s target', (targetName) => {
+    let target;
+    let globalHeaders;
+
+    beforeAll(() => {
+      target = hostingTargets.find((h) => h.target === targetName);
+      const globalEntry = target?.headers?.find((entry) => entry.source === '**');
+      globalHeaders = globalEntry?.headers || [];
+    });
+
+    it(`should have a "${targetName}" hosting target`, () => {
+      expect(target).toBeDefined();
+    });
+
+    it('should have a global headers entry with source "**"', () => {
+      const globalEntry = target.headers.find((entry) => entry.source === '**');
+      expect(globalEntry).toBeDefined();
+    });
+
+    it.each(REQUIRED_SECURITY_HEADERS.map((h) => [h.key, h.value]))(
+      'should include %s header',
+      (headerKey, expectedValue) => {
+        const header = globalHeaders.find((h) => h.key === headerKey);
+        expect(header).toBeDefined();
+        if (expectedValue) {
+          expect(header.value).toBe(expectedValue);
+        }
+      }
+    );
+
+    it('should have HSTS with max-age of at least 1 year', () => {
+      const hsts = globalHeaders.find(
+        (h) => h.key === 'Strict-Transport-Security'
+      );
+      expect(hsts).toBeDefined();
+      expect(hsts.value).toContain('max-age=31536000');
+      expect(hsts.value).toContain('includeSubDomains');
+    });
+
+    it('should have Permissions-Policy disabling dangerous APIs', () => {
+      const pp = globalHeaders.find((h) => h.key === 'Permissions-Policy');
+      expect(pp).toBeDefined();
+      expect(pp.value).toContain('camera=()');
+      expect(pp.value).toContain('microphone=()');
+      expect(pp.value).toContain('geolocation=()');
+    });
+
+    describe('Content-Security-Policy directives', () => {
+      let cspValue;
+
+      beforeAll(() => {
+        const csp = globalHeaders.find(
+          (h) => h.key === 'Content-Security-Policy'
+        );
+        cspValue = csp?.value || '';
+      });
+
+      it.each(CSP_REQUIRED_DIRECTIVES)(
+        'should contain directive: %s',
+        (directive) => {
+          expect(cspValue).toContain(directive);
+        }
+      );
+
+      it('should allow Firebase domains in connect-src', () => {
+        expect(cspValue).toContain('https://*.googleapis.com');
+        expect(cspValue).toContain('https://*.firebaseio.com');
+        expect(cspValue).toContain('wss://*.firebaseio.com');
+      });
+
+      it('should allow Google Fonts in style-src', () => {
+        expect(cspValue).toContain('https://fonts.googleapis.com');
+      });
+
+      it('should allow MUI unsafe-inline styles', () => {
+        expect(cspValue).toMatch(/style-src[^;]*'unsafe-inline'/);
+      });
+
+      it('should allow Google profile images', () => {
+        expect(cspValue).toContain('https://*.googleusercontent.com');
+      });
+
+      it('should allow service worker registration', () => {
+        expect(cspValue).toMatch(/worker-src[^;]*'self'/);
+      });
+    });
+  });
+
+  it('should have identical security headers on both targets', () => {
+    const getSecurityHeaders = (targetName) => {
+      const target = hostingTargets.find((h) => h.target === targetName);
+      const globalEntry = target.headers.find((entry) => entry.source === '**');
+      return globalEntry.headers;
+    };
+
+    const prodHeaders = getSecurityHeaders('production');
+    const stagingHeaders = getSecurityHeaders('staging');
+
+    expect(prodHeaders).toEqual(stagingHeaders);
+  });
+});


### PR DESCRIPTION
Closes #175

## Summary
Add HTTP security headers and Content-Security-Policy (CSP) to Firebase Hosting configuration for both production and staging targets.

**This is the highest-risk sub-issue in epic #140** due to CSP complexity with MUI runtime styles.

## Headers Added
- `X-Content-Type-Options: nosniff` — prevents MIME sniffing
- `X-Frame-Options: DENY` — prevents clickjacking
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy` — disables camera, microphone, geolocation, payment
- `Strict-Transport-Security` — HSTS with 1-year max-age
- `Content-Security-Policy` — full CSP with MUI, Firebase, Google Fonts support

## CSP Critical Notes
- `style-src 'unsafe-inline'` required for MUI Emotion runtime style injection
- `img-src https://*.googleusercontent.com` required for Google profile photos
- `worker-src 'self'` required for service worker registration
- `connect-src` includes Firebase domains for auth + Firestore
- `font-src https://fonts.gstatic.com` for Google Fonts

## Checklist
- [x] Tests passing (2137/2137 pass, 2 pre-existing flaky timeouts)
- [x] Lint clean (0 errors, 0 warnings)
- [x] 52 static analysis tests for header verification
- [x] Build succeeds
- [x] firebase.json valid JSON verified
- [x] Headers present on both production and staging targets
- [x] Identical security headers on both targets

## Files Changed
- `firebase.json` — added 6 security headers to both hosting targets
- `src/lib/firebaseHosting.test.js` — 52 static analysis tests (new)