### PR TITLE
#191 Rewrite README with user-facing content above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,373 +1,134 @@
-# Ma'aser Tracker 📊
+# Ma'aser Tracker
 
-> A Progressive Web App for tracking Jewish charitable giving (ma'aser - מעשר)
+**Track your ma'aser (tithes) simply and privately.**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![CI](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml)
-[![Deploy](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml)
-
-[English](#english) | [עברית](#hebrew)
-
----
-
-## English
-
-### 🎯 Vision
-
-Ma'aser Tracker is a local-first Progressive Web App that helps Jewish individuals and families track their charitable obligations (ma'aser - 10% of income) with ease and privacy. The app provides a simple, intuitive interface for recording income and donations, calculating obligations, and generating reports—all while keeping your financial data completely private and offline-capable.
-
-### ✨ Features
-
-#### Current Features (v0.1.0)
-- ✅ **Bilingual Support** - Full Hebrew (RTL) and English (LTR) interface
-- ✅ **Income Tracking** - Record income with dates, amounts, and notes
-- ✅ **Donation Tracking** - Track charitable donations (tzedakah)
-- ✅ **Ma'aser Calculation** - Automatic 10% obligation calculation
-- ✅ **Dashboard** - View totals, obligations, and giving status at a glance
-- ✅ **History View** - Browse, edit, and delete past entries
-- ✅ **Offline-First** - Works without internet connection
-- ✅ **Privacy-Focused** - All data stored locally on your device
-- ✅ **Material Design** - Clean, modern UI with Material-UI components
-
-#### In Development (v0.2.0 - Sprint 1-2)
-- 🚧 **IndexedDB Storage** - Robust local database replacing LocalStorage
-- 🚧 **PWA Installation** - Install as native-like app on any device
-- 🚧 **Error Recovery** - Automatic data migration and backup
-- 🚧 **Testing Coverage** - Comprehensive automated testing
-
-#### Planned Features (Roadmap)
-- 📅 **Date Range Filtering** - View entries for custom time periods
-- 🏷️ **Donation Categories** - Organize giving by recipient type
-- 🔄 **Recurring Income** - Set up automatic recurring entries
-- 💱 **Multi-Currency** - Support for international currencies
-- ⚙️ **Settings & Preferences** - Customize ma'aser percentage, theme, etc.
-- ☁️ **Cloud Backup** - Optional Google Sheets sync
-- 📊 **Reports & Analytics** - Monthly/yearly summaries
-- 📄 **Tax Reports** - Generate tax-ready documentation
-- ♿ **Accessibility** - WCAG 2.1 AA compliance
-- 📱 **Haptic Feedback** - Enhanced mobile experience
-
-### 🚀 Getting Started
-
-#### Prerequisites
-- Node.js 18+ and npm
-- Modern web browser (Chrome, Firefox, Safari, Edge)
-
-#### Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/DubiWork/maaser-tracker.git
-cd maaser-tracker
-
-# Install dependencies
-npm install
-
-# Configure Firebase (see Firebase Setup below)
-cp .env.example .env
-# Edit .env with your Firebase credentials
-
-# Run development server
-npm run dev
-
-# Build for production
-npm run build
-
-# Preview production build
-npm run preview
-```
-
-The app will be available at `http://localhost:5173`
-
-#### Firebase Setup
-
-This app requires Firebase for authentication and cloud storage. See [docs/FIREBASE_SETUP.md](docs/FIREBASE_SETUP.md) for detailed setup instructions.
-
-**Quick setup:**
-1. Create a Firebase project at [Firebase Console](https://console.firebase.google.com/)
-2. Enable Google Authentication and Firestore Database
-3. Copy `.env.example` to `.env` and fill in your Firebase credentials
-4. Deploy security rules: `firebase deploy --only firestore:rules`
-
-**Note:** The app works offline-first, but requires Firebase for multi-device sync.
-
-### 🏗️ Architecture
-
-#### Tech Stack
-- **Framework:** React 18 with Vite
-- **UI Library:** Material-UI (MUI) v5
-- **Styling:** Emotion (CSS-in-JS)
-- **Data Layer:** IndexedDB via `idb` library
-- **Cloud Storage:** Firebase Firestore
-- **Authentication:** Firebase Authentication (Google OAuth)
-- **State Management:** React Query (TanStack Query)
-- **Internationalization:** Custom context-based i18n
-- **PWA:** Vite PWA Plugin with Workbox
-
-#### Project Structure
-```
-maaser-tracker/
-├── src/
-│   ├── components/       # React components
-│   │   ├── Dashboard.jsx
-│   │   ├── AddIncome.jsx
-│   │   ├── AddDonation.jsx
-│   │   ├── History.jsx
-│   │   └── ErrorBoundary.jsx
-│   ├── contexts/         # React contexts
-│   │   └── LanguageProvider.jsx
-│   ├── hooks/            # Custom React hooks
-│   │   └── useEntries.js
-│   ├── services/         # Business logic layer
-│   │   ├── db.js         # IndexedDB operations
-│   │   └── migration.js  # Data migration
-│   ├── lib/              # Utilities and configuration
-│   │   ├── queryClient.js
-│   │   └── firebase.js   # Firebase initialization
-│   ├── theme.js          # MUI theme configuration
-│   ├── App.jsx           # Main app component
-│   └── main.jsx          # Entry point
-├── public/               # Static assets
-├── docs/                 # Documentation
-│   └── FIREBASE_SETUP.md # Firebase setup guide
-├── firestore.rules       # Firebase security rules
-├── firebase.json         # Firebase configuration
-├── .env.example          # Environment variables template
-├── PROJECT_PLAN.md       # Detailed project roadmap
-├── SPRINT_PLAN.md        # Sprint planning guide
-└── package.json
-```
-
-### 📖 Usage
-
-#### Adding Income
-1. Click the **"הכנסה"** (Income) tab
-2. Enter the date, amount, and optional notes
-3. See the calculated ma'aser obligation (10%)
-4. Click **"הוסף"** (Add) to save
-
-#### Recording Donations
-1. Click the **"תרומה"** (Donation) tab
-2. Enter donation details
-3. Click **"הוסף"** (Add) to save
-
-#### Viewing Dashboard
-- **Total Income** - Sum of all income entries
-- **Total Donations** - Sum of all donations
-- **Ma'aser Obligation** - 10% of total income
-- **Remaining to Give** - Obligation minus donations
-- **Percentage Given** - Progress toward obligation
-
-### 🤝 Contributing
-
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-#### Development Workflow
-1. Pick an issue from the [Project Board](https://github.com/users/DubiWork/projects/4)
-2. Create a feature branch: `feature/<issue-number>-description`
-3. Make changes following the [Code Style Guide](#code-style)
-4. Write/update tests
-5. Submit a Pull Request
-
-#### Code Style
-- **JavaScript/React**: ES6+, functional components, hooks
-- **Formatting**: 2-space indentation, semicolons
-- **Naming**: camelCase for variables/functions, PascalCase for components
-- **Comments**: JSDoc for functions, inline for complex logic
-- **Commits**: Reference issue numbers (`#2 Add feature`)
-
-### 🧪 Testing
-
-```bash
-# Run all tests
-npm test
-
-# Run tests in watch mode
-npm run test:watch
-
-# Generate coverage report
-npm test -- --coverage
-```
-
-**Test Coverage Requirements:**
-- Services layer: ≥80% statements, ≥75% branches, ≥80% functions, ≥80% lines
-- Current coverage: 201 tests, ~90% overall coverage
-
-### 🚀 Deployment Architecture
-
-This project uses a **dual-deployment strategy** for maximum safety and professional development practices:
-
-#### Production Deployment (GitHub Pages)
-- **URL:** https://dubiwork.github.io/maaser-tracker/
-- **Purpose:** Official production site for real users
-- **Trigger:** Automatic deployment after CI passes on `main` branch
-- **Badge:** [![Deploy](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml)
-
-#### Staging/Preview Deployment (Netlify)
-- **Production URL:** https://maaser-tracker.netlify.app/
-- **Preview URLs:** `https://deploy-preview-<PR#>--maaser-tracker.netlify.app/`
-- **Purpose:** Test features in production-like environment BEFORE merging
-- **Trigger:** Automatic preview deployment for every PR
-- **Badge:** [![Netlify Status](https://api.netlify.com/api/v1/badges/YOUR-BADGE-ID/deploy-status)](https://app.netlify.com/sites/maaser-tracker/deploys)
-
-#### Why Two Platforms?
-
-**Risk Management**
-- Test Firebase integration safely before production
-- Catch bugs in preview environment (not in production)
-- Manual testing on real URLs with real SSL certificates
-- No impact on users when testing new features
-
-**Best Practices**
-- Industry-standard preview deployment workflow
-- Used by Stripe, Vercel, GitHub, and other leading companies
-- Professional development process for early-stage products
-- Zero cost (both platforms offer generous free tiers)
-
-**Workflow:**
-```
-Code → Push to PR → Netlify creates preview URL → Manual testing
-                           ↓
-                    All tests pass? ✅
-                           ↓
-                    Merge to main → GitHub Pages deployment (production)
-                                    Netlify production backup
-```
-
-### 🧪 CI/CD Pipeline
-
-**CI Workflow** (`.github/workflows/ci.yml`)
-- Triggers on: Pull requests and pushes to main
-- Steps:
-  - Linting (ESLint)
-  - Unit tests (Vitest)
-  - Coverage reporting
-  - Coverage threshold enforcement
-- Node version: 20.x
-- Badge: [![CI](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml)
-
-**Deploy Workflow** (`.github/workflows/deploy.yml`)
-- Triggers on: Push to main branch (after CI passes)
-- Steps:
-  - Build production bundle
-  - Deploy to GitHub Pages
-- Badge: [![Deploy](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml)
-
-### 📋 Roadmap
-
-See [PROJECT_PLAN.md](PROJECT_PLAN.md) for the complete roadmap with:
-- 7 epics spanning 14 weeks
-- 26 user stories with detailed acceptance criteria
-- Sprint planning and milestones
-- Technical architecture decisions
-
-Current Sprint: **Sprint 1 - Foundation** (Weeks 1-2)
-
-### ☁️ Data Migration
-
-As of v2.0, Ma'aser Tracker supports cloud sync via Firebase. Your data can be securely stored in the cloud and accessed from any device.
-
-#### For Users
-- Your data automatically migrates to the cloud after sign-in
-- Access your data from any device by signing in with the same Google account
-- Offline changes sync when you're back online
-- Local backup kept for 90 days for safety
-- See [Migration FAQ](docs/MIGRATION_FAQ.md) for common questions
-
-#### For Developers
-- See [Migration Implementation Guide](docs/MIGRATION_IMPLEMENTATION.md) for API documentation
-- See [Migration Rollout Plan](docs/MIGRATION_ROLLOUT.md) for deployment strategy
-- See [Migration Troubleshooting](docs/MIGRATION_TROUBLESHOOTING.md) for support documentation
-- See [Performance Benchmarks](docs/PERFORMANCE_BENCHMARKS.md) for performance data
-
-#### Key Features
-- **GDPR-compliant consent dialog** before migration starts
-- **Last-write-wins duplicate resolution** for handling conflicts
-- **Exponential backoff retry** (2^n seconds, max 3 attempts)
-- **Batch processing** (500 entries per batch for Firestore)
-- **Real-time progress tracking** with cancellation support
-- **Bilingual support** (Hebrew/English) for all messages
-
-### 📜 License
-
-MIT License - see [LICENSE](LICENSE) for details
-
-### 🙏 Acknowledgments
-
-- Built with [React](https://react.dev/) and [Vite](https://vitejs.dev/)
-- UI components from [Material-UI](https://mui.com/)
-- Inspired by traditional Jewish ma'aser practices
-
-### 📞 Support
-
-- **Issues**: [GitHub Issues](https://github.com/DubiWork/maaser-tracker/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/DubiWork/maaser-tracker/discussions)
-
----
-
-## Hebrew
+Ma'aser Tracker helps you record income and donations, calculates your 10% obligation automatically, and shows exactly where you stand -- all without creating an account or sharing your data with anyone.
 
 <div dir="rtl">
-
-### 🎯 חזון
-
-מעקב מעשר הוא אפליקציית Progressive Web App המסייעת ליחידים ומשפחות יהודיות לעקוב אחר התחייבויות הצדקה שלהם (מעשר - 10% מההכנסה) בקלות ובפרטיות. האפליקציה מספקת ממשק פשוט ואינטואיטיבי לרישום הכנסות ותרומות, חישוב התחייבויות ויצירת דוחות - הכל תוך שמירה על הנתונים הפיננסיים שלך פרטיים לחלוטין ויכולת עבודה מקוונת.
-
-### ✨ תכונות
-
-#### תכונות נוכחיות (v0.1.0)
-- ✅ **תמיכה דו-לשונית** - ממשק מלא בעברית (מימין לשמאל) ואנגלית (משמאל לימין)
-- ✅ **מעקב הכנסות** - רשום הכנסות עם תאריכים, סכומים והערות
-- ✅ **מעקב תרומות** - עקוב אחר תרומות צדקה
-- ✅ **חישוב מעשר** - חישוב אוטומטי של חובת 10%
-- ✅ **לוח בקרה** - צפה בסכומים, התחייבויות ומצב נתינה במבט אחד
-- ✅ **תצוגת היסטוריה** - עיין, ערוך ומחק רשומות קודמות
-- ✅ **עבודה אופליין** - פועל ללא חיבור אינטרנט
-- ✅ **פרטיות** - כל הנתונים נשמרים מקומית במכשיר שלך
-- ✅ **עיצוב Material** - ממשק נקי ומודרני עם רכיבי Material-UI
-
-#### בפיתוח (v0.2.0 - ספרינט 1-2)
-- 🚧 **אחסון IndexedDB** - מאגר מקומי חזק המחליף את LocalStorage
-- 🚧 **התקנת PWA** - התקן כאפליקציה דמוית-native על כל מכשיר
-- 🚧 **שחזור שגיאות** - העברת נתונים וגיבוי אוטומטיים
-- 🚧 **כיסוי בדיקות** - בדיקות אוטומטיות מקיפות
-
-#### תכונות מתוכננות (מפת דרכים)
-- 📅 **סינון טווח תאריכים** - צפה ברשומות לתקופות זמן מותאמות אישית
-- 🏷️ **קטגוריות תרומות** - ארגן נתינה לפי סוג מקבל
-- 🔄 **הכנסה חוזרת** - הגדר רשומות חוזרות אוטומטיות
-- 💱 **מטבעות מרובים** - תמיכה במטבעות בינלאומיים
-- ⚙️ **הגדרות** - התאם אישית אחוז מעשר, ערכת נושא וכו'
-- ☁️ **גיבוי ענן** - סנכרון אופציונלי ל-Google Sheets
-- 📊 **דוחות וניתוח** - סיכומים חודשיים/שנתיים
-- 📄 **דוחות מס** - יצר תיעוד מוכן למס
-- ♿ **נגישות** - תאימות WCAG 2.1 AA
-- 📱 **משוב מישוש** - חוויית מובייל משופרת
-
-### 🚀 התחלת עבודה
-
-```bash
-# שכפל את המאגר
-git clone https://github.com/DubiWork/maaser-tracker.git
-cd maaser-tracker
-
-# התקן תלויות
-npm install
-
-# הרץ שרת פיתוח
-npm run dev
-```
-
-האפליקציה תהיה זמינה ב-`http://localhost:5173`
-
-### 📞 תמיכה
-
-- **בעיות**: [GitHub Issues](https://github.com/DubiWork/maaser-tracker/issues)
-- **דיונים**: [GitHub Discussions](https://github.com/DubiWork/maaser-tracker/discussions)
-
+<em>
+  .      --
+</em>
 </div>
+
+<br>
+
+[**Try it now**](https://dubiwork.github.io/maaser-tracker/) -- free, no sign-up required.
+
+## Features
+
+- **Track income and donations** -- Add entries with dates, amounts, and notes. See your ma'aser balance update instantly.
+- **Works without internet** -- Everything runs in the browser. Use it on Shabbat prep, on the go, or anywhere.
+- **Your data stays private** -- Financial data is stored on your device. Nothing is sent to a server unless you choose to sync.
+- **Install on any device** -- Add it to your home screen on iPhone, Android, or desktop. It works like a native app.
+- **Hebrew and English** -- Full interface in both languages, with proper right-to-left support for Hebrew.
+- **Import and export your data** -- Bring in data from a CSV or export everything for your records.
+
+## Quick Start
+
+1. **Open the app** at [dubiwork.github.io/maaser-tracker](https://dubiwork.github.io/maaser-tracker/)
+2. **Add your income and donations** using the simple entry form
+3. **See your ma'aser balance** calculated automatically on the dashboard
+
+No account needed. No installation needed. Just open and start tracking.
+
+## Privacy
+
+Your financial information is sensitive. Ma'aser Tracker is built with that in mind:
+
+- **No account required** -- use the app without signing up
+- **Data stays on your device** -- stored locally in your browser
+- **No ads, no tracking** -- zero third-party analytics or advertising
+- **Open source** -- the code is public, so anyone can verify how it works
+- **Optional cloud sync** -- if you want multi-device access, you choose when to enable it
 
 ---
 
-**Made with ❤️ for the Jewish community**
+## For Developers
+
+[![CI](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/ci.yml)
+[![Deploy](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml/badge.svg)](https://github.com/DubiWork/maaser-tracker/actions/workflows/deploy.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/DubiWork/maaser-tracker/issues)
+
+### Tech Stack
+
+- **Framework:** React 19 + Vite 7
+- **UI:** Material-UI (MUI) v6
+- **Data:** IndexedDB (local, via `idb`) + Firebase Firestore (cloud)
+- **Auth:** Firebase Authentication (Google OAuth)
+- **State:** React Query (TanStack Query)
+- **i18n:** Custom context-based (Hebrew RTL / English LTR)
+- **PWA:** Vite PWA Plugin with Workbox
+- **Testing:** Vitest + jsdom (2100+ unit tests), Playwright (41 e2e regression tests)
+
+### Setup
+
+```bash
+git clone https://github.com/DubiWork/maaser-tracker.git
+cd maaser-tracker
+npm install
+
+# Configure Firebase (optional -- app works offline without it)
+cp .env.example .env.local
+# Edit .env.local with your Firebase credentials (see docs/FIREBASE_SETUP.md)
+
+npm run dev
+# App runs at http://localhost:5173/maaser-tracker/
+```
+
+### Testing
+
+```bash
+npm test                    # Run all unit tests
+npm test -- --coverage      # Run with coverage report
+npm run lint                # ESLint
+npx playwright test         # E2e regression suite
+```
+
+**Coverage requirements:** Services layer >= 80% statements, >= 75% branches, >= 80% functions, >= 80% lines.
+
+### Project Structure
+
+```
+src/
+  components/       React components (Dashboard, AddEntryForm, History, etc.)
+  services/         Data layer (IndexedDB CRUD, migration engine)
+  hooks/            React Query hooks (useEntries, useInstallPrompt, useMigration)
+  contexts/         Language context (i18n)
+  translations/     English and Hebrew translation files
+  lib/              Firebase init, React Query client
+e2e/
+  regression/       Playwright regression specs (10 spec files, 41 tests)
+  progression/      Feature progression specs
+  helpers/          Shared test utilities
+```
+
+### Architecture
+
+- **Offline-first:** IndexedDB for local storage, optional Firestore sync
+- **Migration engine:** Batch processing with GDPR-compliant consent, duplicate resolution, retry with exponential backoff
+- **Dual deployment:** GitHub Pages (production) + Netlify (preview per PR)
+- **CI/CD:** GitHub Actions -- lint, test, coverage check on every PR; auto-deploy on merge to main
+
+### Contributing
+
+1. Pick an issue from the [project board](https://github.com/users/DubiWork/projects/4)
+2. Create a branch: `feature/<issue-number>-description`
+3. Write tests for your changes
+4. Submit a pull request referencing the issue
+
+### Documentation
+
+- [Firebase Setup Guide](docs/FIREBASE_SETUP.md)
+- [Migration FAQ](docs/MIGRATION_FAQ.md)
+- [Migration Implementation](docs/MIGRATION_IMPLEMENTATION.md)
+- [Performance Benchmarks](docs/PERFORMANCE_BENCHMARKS.md)
+- [Deployment Monitoring](docs/DEPLOYMENT_MONITORING.md)
+
+### License
+
+MIT
+
+---
+
+**Built for the Jewish community.**


### PR DESCRIPTION
## Summary

- Rewrites README to put user-facing content above the fold, targeting observant Jewish families
- Hero section with plain-language description, Hebrew one-liner, and "Try it now" link
- Features described in user language (not developer jargon)
- 3-step quick start for non-technical users
- Privacy section building trust (no account, no ads, no tracking, open source)
- All existing developer content preserved below a `---` divider (tech stack, setup, testing, architecture, contributing, docs links)

## Test plan

- [ ] README renders correctly on GitHub (headings, links, badges, Hebrew RTL block)
- [ ] "Try it now" link works: https://dubiwork.github.io/maaser-tracker/
- [ ] All documentation links in "For Developers" section resolve
- [ ] No broken badge images

Closes #191