### PR TITLE
#200 Fix Google Sign-In on mobile browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Track your ma'aser (tithe) donations - מעקב מעשר" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; frame-src https://accounts.google.com https://*.firebaseapp.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; frame-src https://accounts.google.com https://*.firebaseapp.com https://*.web.app;">
 
     <!-- iOS PWA meta tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/components/MigrationPrompt.test.jsx
+++ b/src/components/MigrationPrompt.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock the db service

--- a/src/components/SignInButton.test.jsx
+++ b/src/components/SignInButton.test.jsx
@@ -13,6 +13,7 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 import { onAuthStateChanged } from '../services/auth';

--- a/src/components/SignInDialog.jsx
+++ b/src/components/SignInDialog.jsx
@@ -45,6 +45,7 @@ function SignInDialog({ open, onClose }) {
   const { t, direction } = useLanguage();
   const { signIn, clearError } = useAuth();
   const [loading, setLoading] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
   const [error, setError] = useState(null);
 
   const handleSignIn = useCallback(async () => {
@@ -52,7 +53,16 @@ function SignInDialog({ open, onClose }) {
     setError(null);
 
     try {
-      await signIn();
+      const result = await signIn();
+
+      if (result === null) {
+        // Redirect flow initiated (mobile) -- page will navigate away.
+        // Show a brief "redirecting" state in case there is a delay.
+        setRedirecting(true);
+        setLoading(false);
+        return;
+      }
+
       onClose(); // Close dialog on successful sign-in
     } catch (err) {
       // Handle specific error types
@@ -68,6 +78,10 @@ function SignInDialog({ open, onClose }) {
         errorMessage = t.popupBlocked || err.message;
       } else if (err.code === 'network-error') {
         errorMessage = t.networkError || err.message;
+      } else if (err.code === 'operation-not-allowed') {
+        errorMessage = t.operationNotAllowed || err.message;
+      } else if (err.code === 'unauthorized-domain') {
+        errorMessage = t.unauthorizedDomain || err.message;
       } else {
         errorMessage = t.signInError || err.message;
       }
@@ -162,18 +176,20 @@ function SignInDialog({ open, onClose }) {
           variant="contained"
           fullWidth
           size="large"
-          startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <GoogleIcon />}
+          startIcon={(loading || redirecting) ? <CircularProgress size={20} color="inherit" /> : <GoogleIcon />}
           onClick={handleSignIn}
-          disabled={loading}
+          disabled={loading || redirecting}
           sx={{
             py: 1.5,
             textTransform: 'none',
             fontWeight: 600,
           }}
         >
-          {loading
-            ? (t.loading || 'Loading...')
-            : (t.signInWithGoogle || 'Sign in with Google')
+          {redirecting
+            ? (t.redirecting || 'Redirecting...')
+            : loading
+              ? (t.loading || 'Loading...')
+              : (t.signInWithGoogle || 'Sign in with Google')
           }
         </Button>
 

--- a/src/components/SignInDialog.test.jsx
+++ b/src/components/SignInDialog.test.jsx
@@ -13,9 +13,10 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn(),
 }));
 
-import { signInWithGoogle, onAuthStateChanged } from '../services/auth';
+import { signInWithGoogle, onAuthStateChanged, handleRedirectResult } from '../services/auth';
 
 // Helper to render with providers
 function renderWithProviders(ui) {
@@ -23,6 +24,7 @@ function renderWithProviders(ui) {
     callback(null);
     return vi.fn();
   });
+  handleRedirectResult.mockResolvedValue(null);
 
   return render(
     <LanguageProvider>
@@ -157,6 +159,53 @@ describe('SignInDialog', () => {
     });
   });
 
+  describe('mobile redirect flow', () => {
+    it('should show redirecting state when signIn returns null', async () => {
+      // null signals redirect in progress (mobile flow)
+      signInWithGoogle.mockResolvedValueOnce(null);
+
+      renderWithProviders(<SignInDialog open={true} onClose={mockOnClose} />);
+
+      const signInButton = screen.getByRole('button', { name: /התחבר עם Google/i });
+      fireEvent.click(signInButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /מפנה|Redirecting/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should not close dialog when redirect is in progress', async () => {
+      signInWithGoogle.mockResolvedValueOnce(null);
+
+      renderWithProviders(<SignInDialog open={true} onClose={mockOnClose} />);
+
+      const signInButton = screen.getByRole('button', { name: /התחבר עם Google/i });
+      fireEvent.click(signInButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /מפנה|Redirecting/i })).toBeInTheDocument();
+      });
+
+      // Dialog should NOT have been closed
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('should not show error when redirect is in progress', async () => {
+      signInWithGoogle.mockResolvedValueOnce(null);
+
+      renderWithProviders(<SignInDialog open={true} onClose={mockOnClose} />);
+
+      const signInButton = screen.getByRole('button', { name: /התחבר עם Google/i });
+      fireEvent.click(signInButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /מפנה|Redirecting/i })).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
   describe('error handling', () => {
     it('should display error on sign in failure', async () => {
       const error = new Error('Sign in failed');
@@ -202,6 +251,36 @@ describe('SignInDialog', () => {
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
         expect(screen.getByText(/שגיאת רשת/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should display operation-not-allowed error message', async () => {
+      const error = new Error('Not allowed');
+      error.code = 'operation-not-allowed';
+      signInWithGoogle.mockRejectedValueOnce(error);
+
+      renderWithProviders(<SignInDialog open={true} onClose={mockOnClose} />);
+
+      const signInButton = screen.getByRole('button', { name: /התחבר עם Google/i });
+      fireEvent.click(signInButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+    });
+
+    it('should display unauthorized-domain error message', async () => {
+      const error = new Error('Unauthorized');
+      error.code = 'unauthorized-domain';
+      signInWithGoogle.mockRejectedValueOnce(error);
+
+      renderWithProviders(<SignInDialog open={true} onClose={mockOnClose} />);
+
+      const signInButton = screen.getByRole('button', { name: /התחבר עם Google/i });
+      fireEvent.click(signInButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
       });
     });
 

--- a/src/components/UserProfile.test.jsx
+++ b/src/components/UserProfile.test.jsx
@@ -14,6 +14,7 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock the useMigration hook

--- a/src/components/privacy-routing.test.jsx
+++ b/src/components/privacy-routing.test.jsx
@@ -27,6 +27,7 @@ vi.mock('../services/auth', () => ({
     callback(null);
     return vi.fn();
   }),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../services/db', () => ({

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -21,6 +21,7 @@ import {
   signInWithGoogle,
   signOut as authSignOut,
   onAuthStateChanged,
+  handleRedirectResult,
 } from '../services/auth';
 
 export function AuthProvider({ children }) {
@@ -28,10 +29,20 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Subscribe to auth state changes on mount
+  // Subscribe to auth state changes on mount and handle pending redirect
   useEffect(() => {
     const unsubscribe = onAuthStateChanged((authUser) => {
       setUser(authUser);
+      setLoading(false);
+    });
+
+    // Handle redirect result from mobile sign-in flow.
+    // If the user was redirected to Google and came back, this picks up the result.
+    handleRedirectResult().catch((err) => {
+      // Only set error if it's not a cancellation
+      if (err.code !== 'cancelled') {
+        setError(err);
+      }
       setLoading(false);
     });
 

--- a/src/contexts/AuthProvider.test.jsx
+++ b/src/contexts/AuthProvider.test.jsx
@@ -12,6 +12,7 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 import { onAuthStateChanged } from '../services/auth';

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -147,6 +147,9 @@ const translations = {
     signInCancelled: 'ההתחברות בוטלה',
     popupBlocked: 'חלון ההתחברות נחסם. אנא אפשר חלונות קופצים לאתר זה.',
     networkError: 'שגיאת רשת. אנא בדוק את חיבור האינטרנט.',
+    redirecting: 'מפנה...',
+    operationNotAllowed: 'התחברות עם Google לא מופעלת. אנא פנה לתמיכה.',
+    unauthorizedDomain: 'דומיין זה אינו מורשה להתחברות. אנא פנה לתמיכה.',
     privacyPolicyLink: 'מדיניות פרטיות',
 
     // Data Management - GDPR
@@ -550,6 +553,9 @@ const translations = {
     signInCancelled: 'Sign in cancelled',
     popupBlocked: 'Sign-in popup was blocked. Please allow popups for this site.',
     networkError: 'Network error. Please check your internet connection.',
+    redirecting: 'Redirecting...',
+    operationNotAllowed: 'Google Sign-In is not enabled. Please contact support.',
+    unauthorizedDomain: 'This domain is not authorized for sign-in. Please contact support.',
     privacyPolicyLink: 'Privacy Policy',
 
     // Data Management - GDPR

--- a/src/hooks/useAuth.test.js
+++ b/src/hooks/useAuth.test.js
@@ -12,6 +12,7 @@ vi.mock('../services/auth', () => ({
   signInWithGoogle: vi.fn(),
   signOut: vi.fn(),
   onAuthStateChanged: vi.fn(),
+  handleRedirectResult: vi.fn().mockResolvedValue(null),
 }));
 
 import {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -4,16 +4,23 @@
  * Provides Firebase Authentication functionality with Google Sign-In.
  * Authentication is OPTIONAL - the app works fully without signing in.
  *
+ * Uses signInWithRedirect on mobile browsers (popup is unreliable) and
+ * signInWithPopup on desktop browsers.
+ *
  * Functions:
- * - signInWithGoogle() - Trigger Google OAuth popup
+ * - signInWithGoogle() - Trigger Google OAuth (popup on desktop, redirect on mobile)
+ * - handleRedirectResult() - Process redirect result on app startup (mobile flow)
  * - signOut() - Sign out current user
  * - getCurrentUser() - Get current authenticated user
  * - onAuthStateChanged(callback) - Listen for auth state changes
+ * - isMobileBrowser() - Detect mobile browser environment
  */
 
 import {
   GoogleAuthProvider,
   signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
   signOut as firebaseSignOut,
   onAuthStateChanged as firebaseOnAuthStateChanged,
 } from 'firebase/auth';
@@ -28,6 +35,15 @@ googleProvider.setCustomParameters({
 });
 
 /**
+ * Detect if the current browser is a mobile device.
+ * Used to choose between popup (desktop) and redirect (mobile) sign-in flows.
+ * @returns {boolean}
+ */
+export function isMobileBrowser() {
+  return /Android|iPhone|iPad|iPod|Opera Mini|IEMobile/i.test(navigator.userAgent);
+}
+
+/**
  * Error codes for authentication errors
  */
 export const AUTH_ERROR_CODES = {
@@ -35,61 +51,120 @@ export const AUTH_ERROR_CODES = {
   POPUP_BLOCKED: 'auth/popup-blocked',
   NETWORK_ERROR: 'auth/network-request-failed',
   CANCELLED: 'auth/cancelled-popup-request',
+  OPERATION_NOT_ALLOWED: 'auth/operation-not-allowed',
+  UNAUTHORIZED_DOMAIN: 'auth/unauthorized-domain',
 };
 
 /**
- * Sign in with Google using popup
- * @returns {Promise<{user: Object, isNewUser: boolean}>} User object and new user flag
+ * Sign in with Google.
+ * Uses signInWithRedirect on mobile (popup is unreliable) and signInWithPopup on desktop.
+ * @returns {Promise<{user: Object, isNewUser: boolean}|null>} User object and new user flag,
+ *   or null if redirect flow was initiated (page will navigate away).
  * @throws {Error} If sign-in fails
  */
 export async function signInWithGoogle() {
   try {
+    if (isMobileBrowser()) {
+      // Mobile: redirect flow. The page will navigate away.
+      // After redirect, handleRedirectResult() picks up the result on next load.
+      await signInWithRedirect(auth, googleProvider);
+      // signInWithRedirect resolves with void before the redirect happens.
+      return null; // Signal: redirect in progress
+    }
+
+    // Desktop: popup flow
     const result = await signInWithPopup(auth, googleProvider);
-    const user = result.user;
-
-    // Check if this is a new user (first sign-in)
-    const isNewUser = result._tokenResponse?.isNewUser ?? false;
-
-    return {
-      user: {
-        uid: user.uid,
-        email: user.email,
-        displayName: user.displayName,
-        photoURL: user.photoURL,
-      },
-      isNewUser,
-    };
+    return extractUserResult(result);
   } catch (error) {
-    // Re-throw with more context for specific error types
-    if (error.code === AUTH_ERROR_CODES.POPUP_CLOSED) {
-      const cancelledError = new Error('Sign-in was cancelled');
-      cancelledError.code = 'cancelled';
-      throw cancelledError;
-    }
-
-    if (error.code === AUTH_ERROR_CODES.POPUP_BLOCKED) {
-      const blockedError = new Error('Sign-in popup was blocked. Please allow popups for this site.');
-      blockedError.code = 'popup-blocked';
-      throw blockedError;
-    }
-
-    if (error.code === AUTH_ERROR_CODES.NETWORK_ERROR) {
-      const networkError = new Error('Network error. Please check your internet connection.');
-      networkError.code = 'network-error';
-      throw networkError;
-    }
-
-    if (error.code === AUTH_ERROR_CODES.CANCELLED) {
-      const cancelledError = new Error('Sign-in was cancelled');
-      cancelledError.code = 'cancelled';
-      throw cancelledError;
-    }
-
-    // Generic error
-    const genericError = new Error(error.message || 'Sign-in failed');
-    genericError.code = error.code || 'unknown';
-    throw genericError;
+    throw mapAuthError(error);
   }
+}
+
+/**
+ * Handle the redirect result after the page reloads from a Google sign-in redirect.
+ * Must be called once on app startup.
+ * @returns {Promise<{user: Object, isNewUser: boolean}|null>} User data if redirect completed,
+ *   or null if there was no pending redirect.
+ * @throws {Error} If the redirect sign-in failed
+ */
+export async function handleRedirectResult() {
+  try {
+    const result = await getRedirectResult(auth);
+    if (!result) {
+      return null; // No pending redirect
+    }
+    return extractUserResult(result);
+  } catch (error) {
+    throw mapAuthError(error);
+  }
+}
+
+/**
+ * Extract a normalized user result from a Firebase auth credential result.
+ * @param {Object} result - Firebase UserCredential
+ * @returns {{user: Object, isNewUser: boolean}}
+ */
+function extractUserResult(result) {
+  const user = result.user;
+  const isNewUser = result._tokenResponse?.isNewUser ?? false;
+
+  return {
+    user: {
+      uid: user.uid,
+      email: user.email,
+      displayName: user.displayName,
+      photoURL: user.photoURL,
+    },
+    isNewUser,
+  };
+}
+
+/**
+ * Map Firebase auth errors to user-friendly errors with stable codes.
+ * @param {Error} error - Firebase auth error
+ * @returns {Error} Mapped error with code property
+ */
+function mapAuthError(error) {
+  if (error.code === AUTH_ERROR_CODES.POPUP_CLOSED) {
+    const cancelledError = new Error('Sign-in was cancelled');
+    cancelledError.code = 'cancelled';
+    return cancelledError;
+  }
+
+  if (error.code === AUTH_ERROR_CODES.POPUP_BLOCKED) {
+    const blockedError = new Error('Sign-in popup was blocked. Please allow popups for this site.');
+    blockedError.code = 'popup-blocked';
+    return blockedError;
+  }
+
+  if (error.code === AUTH_ERROR_CODES.NETWORK_ERROR) {
+    const networkError = new Error('Network error. Please check your internet connection.');
+    networkError.code = 'network-error';
+    return networkError;
+  }
+
+  if (error.code === AUTH_ERROR_CODES.CANCELLED) {
+    const cancelledError = new Error('Sign-in was cancelled');
+    cancelledError.code = 'cancelled';
+    return cancelledError;
+  }
+
+  if (error.code === AUTH_ERROR_CODES.OPERATION_NOT_ALLOWED) {
+    const notAllowedError = new Error('Google Sign-In is not enabled. Please contact support.');
+    notAllowedError.code = 'operation-not-allowed';
+    return notAllowedError;
+  }
+
+  if (error.code === AUTH_ERROR_CODES.UNAUTHORIZED_DOMAIN) {
+    const domainError = new Error('This domain is not authorized for sign-in. Please contact support.');
+    domainError.code = 'unauthorized-domain';
+    return domainError;
+  }
+
+  // Generic error
+  const genericError = new Error(error.message || 'Sign-in failed');
+  genericError.code = error.code || 'unknown';
+  return genericError;
 }
 
 /**

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -16,6 +16,8 @@ vi.mock('firebase/auth', () => {
   return {
     GoogleAuthProvider: MockGoogleAuthProvider,
     signInWithPopup: vi.fn(),
+    signInWithRedirect: vi.fn(),
+    getRedirectResult: vi.fn(),
     signOut: vi.fn(),
     onAuthStateChanged: vi.fn(),
   };
@@ -29,6 +31,8 @@ vi.mock('../lib/firebase', () => ({
 
 import {
   signInWithGoogle,
+  handleRedirectResult,
+  isMobileBrowser,
   signOut,
   getCurrentUser,
   onAuthStateChanged,
@@ -36,124 +40,304 @@ import {
 } from './auth';
 import {
   signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
   signOut as firebaseSignOut,
   onAuthStateChanged as firebaseOnAuthStateChanged,
 } from 'firebase/auth';
 import { auth } from '../lib/firebase';
 
+// Helper to set userAgent for mobile detection tests
+function setUserAgent(value) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe('auth service', () => {
+  const originalUserAgent = navigator.userAgent;
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset auth.currentUser
     auth.currentUser = null;
+    // Reset userAgent to desktop
+    setUserAgent(originalUserAgent);
+  });
+
+  describe('isMobileBrowser', () => {
+    it('should return false for desktop browsers', () => {
+      setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
+      expect(isMobileBrowser()).toBe(false);
+    });
+
+    it('should return true for Android', () => {
+      setUserAgent('Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Mobile');
+      expect(isMobileBrowser()).toBe(true);
+    });
+
+    it('should return true for iPhone', () => {
+      setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15');
+      expect(isMobileBrowser()).toBe(true);
+    });
+
+    it('should return true for iPad', () => {
+      setUserAgent('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15');
+      expect(isMobileBrowser()).toBe(true);
+    });
+
+    it('should return true for Opera Mini', () => {
+      setUserAgent('Opera/9.80 (J2ME/MIDP; Opera Mini/5.0) Presto/2.8.119');
+      expect(isMobileBrowser()).toBe(true);
+    });
   });
 
   describe('signInWithGoogle', () => {
-    it('should sign in successfully and return user data', async () => {
-      const mockUser = {
-        uid: 'test-uid-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        photoURL: 'https://example.com/photo.jpg',
-      };
-
-      signInWithPopup.mockResolvedValueOnce({
-        user: mockUser,
-        _tokenResponse: { isNewUser: false },
+    describe('desktop (popup flow)', () => {
+      beforeEach(() => {
+        setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
       });
 
-      const result = await signInWithGoogle();
+      it('should sign in successfully and return user data', async () => {
+        const mockUser = {
+          uid: 'test-uid-123',
+          email: 'test@example.com',
+          displayName: 'Test User',
+          photoURL: 'https://example.com/photo.jpg',
+        };
 
-      expect(result.user).toEqual({
-        uid: 'test-uid-123',
-        email: 'test@example.com',
-        displayName: 'Test User',
-        photoURL: 'https://example.com/photo.jpg',
+        signInWithPopup.mockResolvedValueOnce({
+          user: mockUser,
+          _tokenResponse: { isNewUser: false },
+        });
+
+        const result = await signInWithGoogle();
+
+        expect(result.user).toEqual({
+          uid: 'test-uid-123',
+          email: 'test@example.com',
+          displayName: 'Test User',
+          photoURL: 'https://example.com/photo.jpg',
+        });
+        expect(result.isNewUser).toBe(false);
+        expect(signInWithPopup).toHaveBeenCalled();
+        expect(signInWithRedirect).not.toHaveBeenCalled();
       });
-      expect(result.isNewUser).toBe(false);
+
+      it('should detect new users', async () => {
+        const mockUser = {
+          uid: 'new-user-123',
+          email: 'new@example.com',
+          displayName: 'New User',
+          photoURL: null,
+        };
+
+        signInWithPopup.mockResolvedValueOnce({
+          user: mockUser,
+          _tokenResponse: { isNewUser: true },
+        });
+
+        const result = await signInWithGoogle();
+
+        expect(result.isNewUser).toBe(true);
+      });
+
+      it('should handle popup closed by user', async () => {
+        const error = new Error('Popup closed');
+        error.code = AUTH_ERROR_CODES.POPUP_CLOSED;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Sign-in was cancelled',
+          code: 'cancelled',
+        });
+      });
+
+      it('should handle popup blocked error', async () => {
+        const error = new Error('Popup blocked');
+        error.code = AUTH_ERROR_CODES.POPUP_BLOCKED;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Sign-in popup was blocked. Please allow popups for this site.',
+          code: 'popup-blocked',
+        });
+      });
+
+      it('should handle network error', async () => {
+        const error = new Error('Network error');
+        error.code = AUTH_ERROR_CODES.NETWORK_ERROR;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Network error. Please check your internet connection.',
+          code: 'network-error',
+        });
+      });
+
+      it('should handle cancelled popup request', async () => {
+        const error = new Error('Cancelled');
+        error.code = AUTH_ERROR_CODES.CANCELLED;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Sign-in was cancelled',
+          code: 'cancelled',
+        });
+      });
+
+      it('should handle operation-not-allowed error', async () => {
+        const error = new Error('Operation not allowed');
+        error.code = AUTH_ERROR_CODES.OPERATION_NOT_ALLOWED;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Google Sign-In is not enabled. Please contact support.',
+          code: 'operation-not-allowed',
+        });
+      });
+
+      it('should handle unauthorized-domain error', async () => {
+        const error = new Error('Unauthorized domain');
+        error.code = AUTH_ERROR_CODES.UNAUTHORIZED_DOMAIN;
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'This domain is not authorized for sign-in. Please contact support.',
+          code: 'unauthorized-domain',
+        });
+      });
+
+      it('should handle generic errors', async () => {
+        const error = new Error('Something went wrong');
+        error.code = 'auth/unknown-error';
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Something went wrong',
+          code: 'auth/unknown-error',
+        });
+      });
+
+      it('should handle errors without message', async () => {
+        const error = new Error();
+        error.code = 'auth/error';
+        signInWithPopup.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Sign-in failed',
+          code: 'auth/error',
+        });
+      });
     });
 
-    it('should detect new users', async () => {
+    describe('mobile (redirect flow)', () => {
+      beforeEach(() => {
+        setUserAgent('Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Mobile');
+      });
+
+      it('should use signInWithRedirect on mobile and return null', async () => {
+        signInWithRedirect.mockResolvedValueOnce(undefined);
+
+        const result = await signInWithGoogle();
+
+        expect(result).toBeNull();
+        expect(signInWithRedirect).toHaveBeenCalled();
+        expect(signInWithPopup).not.toHaveBeenCalled();
+      });
+
+      it('should handle redirect errors', async () => {
+        const error = new Error('Network error');
+        error.code = AUTH_ERROR_CODES.NETWORK_ERROR;
+        signInWithRedirect.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Network error. Please check your internet connection.',
+          code: 'network-error',
+        });
+      });
+
+      it('should handle operation-not-allowed on redirect', async () => {
+        const error = new Error('Not allowed');
+        error.code = AUTH_ERROR_CODES.OPERATION_NOT_ALLOWED;
+        signInWithRedirect.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'Google Sign-In is not enabled. Please contact support.',
+          code: 'operation-not-allowed',
+        });
+      });
+
+      it('should handle unauthorized-domain on redirect', async () => {
+        const error = new Error('Unauthorized');
+        error.code = AUTH_ERROR_CODES.UNAUTHORIZED_DOMAIN;
+        signInWithRedirect.mockRejectedValueOnce(error);
+
+        await expect(signInWithGoogle()).rejects.toMatchObject({
+          message: 'This domain is not authorized for sign-in. Please contact support.',
+          code: 'unauthorized-domain',
+        });
+      });
+    });
+  });
+
+  describe('handleRedirectResult', () => {
+    it('should return null when there is no pending redirect', async () => {
+      getRedirectResult.mockResolvedValueOnce(null);
+
+      const result = await handleRedirectResult();
+
+      expect(result).toBeNull();
+      expect(getRedirectResult).toHaveBeenCalled();
+    });
+
+    it('should return user data when redirect completed', async () => {
       const mockUser = {
-        uid: 'new-user-123',
-        email: 'new@example.com',
-        displayName: 'New User',
-        photoURL: null,
+        uid: 'redirect-uid-123',
+        email: 'redirect@example.com',
+        displayName: 'Redirect User',
+        photoURL: 'https://example.com/redirect.jpg',
       };
 
-      signInWithPopup.mockResolvedValueOnce({
+      getRedirectResult.mockResolvedValueOnce({
         user: mockUser,
         _tokenResponse: { isNewUser: true },
       });
 
-      const result = await signInWithGoogle();
+      const result = await handleRedirectResult();
 
-      expect(result.isNewUser).toBe(true);
-    });
-
-    it('should handle popup closed by user', async () => {
-      const error = new Error('Popup closed');
-      error.code = AUTH_ERROR_CODES.POPUP_CLOSED;
-      signInWithPopup.mockRejectedValueOnce(error);
-
-      await expect(signInWithGoogle()).rejects.toMatchObject({
-        message: 'Sign-in was cancelled',
-        code: 'cancelled',
+      expect(result).toEqual({
+        user: {
+          uid: 'redirect-uid-123',
+          email: 'redirect@example.com',
+          displayName: 'Redirect User',
+          photoURL: 'https://example.com/redirect.jpg',
+        },
+        isNewUser: true,
       });
     });
 
-    it('should handle popup blocked error', async () => {
-      const error = new Error('Popup blocked');
-      error.code = AUTH_ERROR_CODES.POPUP_BLOCKED;
-      signInWithPopup.mockRejectedValueOnce(error);
-
-      await expect(signInWithGoogle()).rejects.toMatchObject({
-        message: 'Sign-in popup was blocked. Please allow popups for this site.',
-        code: 'popup-blocked',
-      });
-    });
-
-    it('should handle network error', async () => {
-      const error = new Error('Network error');
+    it('should throw mapped error when redirect failed', async () => {
+      const error = new Error('Network failure');
       error.code = AUTH_ERROR_CODES.NETWORK_ERROR;
-      signInWithPopup.mockRejectedValueOnce(error);
+      getRedirectResult.mockRejectedValueOnce(error);
 
-      await expect(signInWithGoogle()).rejects.toMatchObject({
+      await expect(handleRedirectResult()).rejects.toMatchObject({
         message: 'Network error. Please check your internet connection.',
         code: 'network-error',
       });
     });
 
-    it('should handle cancelled popup request', async () => {
-      const error = new Error('Cancelled');
-      error.code = AUTH_ERROR_CODES.CANCELLED;
-      signInWithPopup.mockRejectedValueOnce(error);
+    it('should throw mapped error for unauthorized domain', async () => {
+      const error = new Error('Unauthorized domain');
+      error.code = AUTH_ERROR_CODES.UNAUTHORIZED_DOMAIN;
+      getRedirectResult.mockRejectedValueOnce(error);
 
-      await expect(signInWithGoogle()).rejects.toMatchObject({
-        message: 'Sign-in was cancelled',
-        code: 'cancelled',
-      });
-    });
-
-    it('should handle generic errors', async () => {
-      const error = new Error('Something went wrong');
-      error.code = 'auth/unknown-error';
-      signInWithPopup.mockRejectedValueOnce(error);
-
-      await expect(signInWithGoogle()).rejects.toMatchObject({
-        message: 'Something went wrong',
-        code: 'auth/unknown-error',
-      });
-    });
-
-    it('should handle errors without message', async () => {
-      const error = new Error();
-      error.code = 'auth/error';
-      signInWithPopup.mockRejectedValueOnce(error);
-
-      await expect(signInWithGoogle()).rejects.toMatchObject({
-        message: 'Sign-in failed',
-        code: 'auth/error',
+      await expect(handleRedirectResult()).rejects.toMatchObject({
+        message: 'This domain is not authorized for sign-in. Please contact support.',
+        code: 'unauthorized-domain',
       });
     });
   });
@@ -284,6 +468,8 @@ describe('auth service', () => {
       expect(AUTH_ERROR_CODES.POPUP_BLOCKED).toBe('auth/popup-blocked');
       expect(AUTH_ERROR_CODES.NETWORK_ERROR).toBe('auth/network-request-failed');
       expect(AUTH_ERROR_CODES.CANCELLED).toBe('auth/cancelled-popup-request');
+      expect(AUTH_ERROR_CODES.OPERATION_NOT_ALLOWED).toBe('auth/operation-not-allowed');
+      expect(AUTH_ERROR_CODES.UNAUTHORIZED_DOMAIN).toBe('auth/unauthorized-domain');
     });
   });
 });


### PR DESCRIPTION
## P0 Hotfix

Google Sign-In fails on mobile Chrome because `signInWithPopup` is unreliable on mobile browsers. Users see a red error alert "something went wrong" when tapping "Sign in with Google" on mobile.

### Root Cause
Firebase's `signInWithPopup` is known to fail on mobile browsers (popup gets blocked or closed by the OS).

### Changes
- **`src/services/auth.js`**: Use `signInWithRedirect` on mobile, `signInWithPopup` on desktop. Added `handleRedirectResult()` for processing the redirect on app reload. Added error handling for `auth/operation-not-allowed` and `auth/unauthorized-domain`.
- **`src/contexts/AuthProvider.jsx`**: Call `handleRedirectResult()` on app startup to complete the mobile redirect sign-in flow.
- **`src/components/SignInDialog.jsx`**: Handle `null` return from `signIn()` (redirect in progress) with a "Redirecting..." state instead of showing an error.
- **`index.html`**: Add `https://*.web.app` to `frame-src` CSP for safety.
- **`src/contexts/LanguageProvider.jsx`**: Add Hebrew/English translations for `redirecting`, `operationNotAllowed`, `unauthorizedDomain`.
- **7 test files**: Updated auth service mocks to include `handleRedirectResult` for AuthProvider compatibility.

### Test Results
- 172 tests across 8 modified test files: all passing
- 1818 total tests passing (pre-existing failures unrelated to this change)
- Lint clean on all modified files

Closes #200