### PR TITLE
#206 Fix CSP blocking Google Sign-In

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Track your ma'aser (tithe) donations - מעקב מעשר" />
 
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; frame-src https://accounts.google.com https://*.firebaseapp.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; img-src 'self' data: https://*.googleusercontent.com; frame-src https://accounts.google.com https://*.firebaseapp.com;">
 
     <!-- iOS PWA meta tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary

- Add `https://apis.google.com` to `script-src` in Content Security Policy meta tag
- This was the root cause of the `auth/internal-error` incident (#202)
- The CSP added by Security Audit (#172) blocked Firebase Auth from loading Google's auth script

## Test Plan

- [ ] Deploy to staging
- [ ] Verify Google Sign-In works on staging
- [ ] Merge to main
- [ ] Verify Google Sign-In works on production

Closes #206
Related: #202