### PR TITLE
#208 Add Google Sign-In smoke tests to regression suite

### DIFF
--- a/.github/REGRESSION_TEST_PLAN.md
+++ b/.github/REGRESSION_TEST_PLAN.md
@@ -39,6 +39,8 @@ For each test case below:
 | RT-Auth-01 | User signed out. | 1. Navigate to app. 2. Click "כניסה" (Sign In). 3. Complete Google sign-in flow. | User signed in. Avatar appears in top bar. No console errors. | @skip-ci |
 | RT-Auth-02 | User signed in. | 1. Click user avatar. 2. Click "יציאה" (Sign Out). | User signed out. Avatar disappears. App still accessible (offline mode). No console errors. | Yes |
 | RT-Auth-03 | User signed out. | 1. Navigate to app. 2. Do NOT sign in. 3. Add an income entry. | Entry saved to local IndexedDB. Dashboard shows entry. No auth required. No console errors. | Yes |
+| RT-Auth-04 | None. | 1. Navigate to app. 2. Check CSP meta tag for `apis.google.com` in script-src. 3. Check console for CSP violations related to Google APIs. | CSP includes `https://apis.google.com` in script-src. No CSP violation errors in console. | Yes |
+| RT-Auth-05 | None. | 1. Navigate to app (registers service worker). 2. Navigate to `/__/auth/handler`. 3. Check if page contains app root element. | Auth handler path is NOT intercepted by service worker. Page does NOT render the app. | Yes |
 
 ---
 

--- a/e2e/regression/authentication.spec.js
+++ b/e2e/regression/authentication.spec.js
@@ -1,7 +1,8 @@
 /**
- * Regression tests: Authentication Flows (RT-Auth-01 through RT-Auth-03)
+ * Regression tests: Authentication Flows (RT-Auth-01 through RT-Auth-05)
  *
- * Covers sign-in (skipped in CI), sign-out, and unauthenticated local usage.
+ * Covers sign-in (skipped in CI), sign-out, unauthenticated local usage,
+ * and smoke tests for CSP and service worker compatibility with Firebase Auth.
  */
 
 import { test, expect } from '../fixtures/console.fixture.js';
@@ -116,5 +117,57 @@ test.describe('Authentication Flows', () => {
     expect(entryCount).toBeGreaterThanOrEqual(1);
 
     expectNoConsoleErrors(consoleMessages);
+  });
+
+  // ---------------------------------------------------------------------------
+  // RT-Auth-04: CSP allows Google Auth script loading
+  // Regression guard for incident #202 — CSP blocked apis.google.com
+  // ---------------------------------------------------------------------------
+  test('RT-Auth-04: CSP does not block Google Auth script', async ({ page }) => {
+    // Collect CSP violation errors
+    const cspErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' && msg.text().includes('Content Security Policy')) {
+        cspErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Check that the CSP meta tag includes apis.google.com in script-src
+    const cspContent = await page.evaluate(() => {
+      const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+      return meta ? meta.getAttribute('content') : null;
+    });
+
+    expect(cspContent).not.toBeNull();
+    expect(cspContent).toContain('https://apis.google.com');
+
+    // Verify no CSP errors related to Google APIs were logged
+    const googleCspErrors = cspErrors.filter((e) => e.includes('apis.google.com'));
+    expect(googleCspErrors).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // RT-Auth-05: Service worker does not intercept Firebase auth handler
+  // Regression guard for incident #202 — SW served index.html for /__/auth/handler
+  // ---------------------------------------------------------------------------
+  test('RT-Auth-05: /__/auth/handler is not intercepted by service worker', async ({ page }) => {
+    // First visit the app to register the service worker
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Now navigate to the Firebase reserved auth handler path
+    const response = await page.goto('/__/auth/handler');
+
+    // The auth handler page should NOT contain the app's root element.
+    // If the service worker intercepts it, it serves index.html with <div id="root">.
+    const hasAppRoot = await page.evaluate(() => {
+      const root = document.getElementById('root');
+      return root !== null && root.children.length > 0;
+    });
+
+    expect(hasAppRoot).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds two automated regression tests that would have caught the root causes of incident #202:

- **RT-Auth-04:** Verifies CSP `script-src` includes `https://apis.google.com` — catches the CSP blocking Google Auth script
- **RT-Auth-05:** Verifies `/__/auth/handler` is not intercepted by service worker — catches the SW serving index.html for Firebase's auth handler

Both tests run in headless CI (no real OAuth needed).

## Test Results

- RT-Auth-04: PASSED
- RT-Auth-05: PASSED
- Pre-existing RT-Auth-02 and RT-Auth-03 failures are unrelated

Closes #208
Related: #202 (incident), #206 (fix)