### PR TITLE
#211 Preset Service Layer (IndexedDB CRUD + React Query Hooks)

### DIFF
--- a/src/hooks/usePresets.js
+++ b/src/hooks/usePresets.js
@@ -1,0 +1,146 @@
+/**
+ * React Query Hooks for Preset Service
+ *
+ * Provides hooks for reading and mutating note presets stored in IndexedDB.
+ * All mutations invalidate the presets query cache so UI stays in sync.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getPresetsByType,
+  addPreset,
+  updatePreset,
+  deletePreset,
+  reorderPresets,
+} from '../services/presetService';
+
+// ─── Query Keys ───────────────────────────────────────────────────────────────
+
+export const presetQueryKeys = {
+  all: ['presets'],
+  lists: () => [...presetQueryKeys.all, 'list'],
+  byType: (type) => [...presetQueryKeys.lists(), type],
+};
+
+// ─── Query Hooks ──────────────────────────────────────────────────────────────
+
+/**
+ * Hook to fetch all presets for a given type, sorted by order.
+ *
+ * @param {string|null} type - 'income' | 'donation' | null (disabled when null)
+ * @returns {Object} React Query result with presets data
+ *
+ * @example
+ * const { data: presets, isLoading } = usePresets('income');
+ */
+export function usePresets(type) {
+  return useQuery({
+    queryKey: presetQueryKeys.byType(type),
+    queryFn: () => getPresetsByType(type),
+    enabled: !!type,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    gcTime: 1000 * 60 * 10,   // 10 minutes
+  });
+}
+
+// ─── Mutation Hooks ───────────────────────────────────────────────────────────
+
+/**
+ * Hook to add a new preset.
+ *
+ * @returns {Object} Mutation object — call `mutate({ text, type })` or `mutateAsync`
+ *
+ * @example
+ * const addPresetMutation = useAddPreset();
+ * addPresetMutation.mutate({ text: 'Consulting', type: 'income' });
+ */
+export function useAddPreset() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ text, type }) => addPreset(text, type),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: presetQueryKeys.all });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) {
+        console.error('useAddPreset: Failed to add preset', error);
+      }
+    },
+  });
+}
+
+/**
+ * Hook to update an existing preset.
+ *
+ * @returns {Object} Mutation object — call `mutate({ id, updates })` or `mutateAsync`
+ *
+ * @example
+ * const updatePresetMutation = useUpdatePreset();
+ * updatePresetMutation.mutate({ id: 1, updates: { text: 'New Label' } });
+ */
+export function useUpdatePreset() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, updates }) => updatePreset(id, updates),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: presetQueryKeys.all });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) {
+        console.error('useUpdatePreset: Failed to update preset', error);
+      }
+    },
+  });
+}
+
+/**
+ * Hook to delete a preset by id.
+ *
+ * @returns {Object} Mutation object — call `mutate(id)` or `mutateAsync(id)`
+ *
+ * @example
+ * const deletePresetMutation = useDeletePreset();
+ * deletePresetMutation.mutate(1);
+ */
+export function useDeletePreset() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id) => deletePreset(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: presetQueryKeys.all });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) {
+        console.error('useDeletePreset: Failed to delete preset', error);
+      }
+    },
+  });
+}
+
+/**
+ * Hook to reorder presets.
+ *
+ * @returns {Object} Mutation object — call `mutate(presetIds)` or `mutateAsync(presetIds)`
+ *
+ * @example
+ * const reorderPresetsMutation = useReorderPresets();
+ * reorderPresetsMutation.mutate([3, 1, 2]); // Sets order: 3→0, 1→1, 2→2
+ */
+export function useReorderPresets() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (presetIds) => reorderPresets(presetIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: presetQueryKeys.all });
+    },
+    onError: (error) => {
+      if (import.meta.env.DEV) {
+        console.error('useReorderPresets: Failed to reorder presets', error);
+      }
+    },
+  });
+}

--- a/src/hooks/usePresets.test.jsx
+++ b/src/hooks/usePresets.test.jsx
@@ -1,0 +1,362 @@
+/**
+ * Tests for usePresets hooks
+ *
+ * Tests cover:
+ * - Fetching presets by type
+ * - CRUD mutations (add, update, delete, reorder)
+ * - Cache invalidation after mutations
+ * - Error handling
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock preset service
+vi.mock('../services/presetService', () => ({
+  getPresetsByType: vi.fn(),
+  addPreset: vi.fn(),
+  updatePreset: vi.fn(),
+  deletePreset: vi.fn(),
+  reorderPresets: vi.fn(),
+  initializeDefaultPresets: vi.fn(),
+}));
+
+import {
+  getPresetsByType,
+  addPreset,
+  updatePreset,
+  deletePreset,
+  reorderPresets,
+} from '../services/presetService';
+
+import {
+  usePresets,
+  useAddPreset,
+  useUpdatePreset,
+  useDeletePreset,
+  useReorderPresets,
+  presetQueryKeys,
+} from './usePresets';
+
+// Sample data
+const mockIncomePresets = [
+  { id: 1, text: 'Salary', type: 'income', isDefault: true, order: 0, createdAt: 1000 },
+  { id: 2, text: 'Bonus', type: 'income', isDefault: true, order: 1, createdAt: 1001 },
+];
+
+const mockDonationPresets = [
+  { id: 3, text: 'Charity Dinner', type: 'donation', isDefault: true, order: 0, createdAt: 1002 },
+];
+
+// Create a wrapper with QueryClientProvider
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+describe('presetQueryKeys', () => {
+  it('should generate correct query keys', () => {
+    expect(presetQueryKeys.all).toEqual(['presets']);
+    expect(presetQueryKeys.lists()).toEqual(['presets', 'list']);
+    expect(presetQueryKeys.byType('income')).toEqual(['presets', 'list', 'income']);
+    expect(presetQueryKeys.byType('donation')).toEqual(['presets', 'list', 'donation']);
+  });
+});
+
+describe('usePresets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch income presets', async () => {
+    getPresetsByType.mockResolvedValue(mockIncomePresets);
+
+    const { result } = renderHook(() => usePresets('income'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getPresetsByType).toHaveBeenCalledWith('income');
+    expect(result.current.data).toEqual(mockIncomePresets);
+  });
+
+  it('should fetch donation presets', async () => {
+    getPresetsByType.mockResolvedValue(mockDonationPresets);
+
+    const { result } = renderHook(() => usePresets('donation'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getPresetsByType).toHaveBeenCalledWith('donation');
+    expect(result.current.data).toEqual(mockDonationPresets);
+  });
+
+  it('should not run query when type is not provided', () => {
+    const { result } = renderHook(() => usePresets(null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetching).toBe(false);
+    expect(getPresetsByType).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetch errors', async () => {
+    getPresetsByType.mockRejectedValue(new Error('DB error'));
+
+    const { result } = renderHook(() => usePresets('income'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});
+
+describe('useAddPreset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should add an income preset', async () => {
+    const newPreset = { id: 10, text: 'Consulting', type: 'income', isDefault: false, order: 2, createdAt: 2000 };
+    addPreset.mockResolvedValue(newPreset);
+
+    const { result } = renderHook(() => useAddPreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ text: 'Consulting', type: 'income' });
+    });
+
+    expect(addPreset).toHaveBeenCalledWith('Consulting', 'income');
+  });
+
+  it('should add a donation preset', async () => {
+    const newPreset = { id: 11, text: 'Local Shelter', type: 'donation', isDefault: false, order: 3, createdAt: 2001 };
+    addPreset.mockResolvedValue(newPreset);
+
+    const { result } = renderHook(() => useAddPreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ text: 'Local Shelter', type: 'donation' });
+    });
+
+    expect(addPreset).toHaveBeenCalledWith('Local Shelter', 'donation');
+  });
+
+  it('should expose standard mutation API', () => {
+    addPreset.mockResolvedValue({});
+
+    const { result } = renderHook(() => useAddPreset(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.mutate).toBeDefined();
+    expect(result.current.mutateAsync).toBeDefined();
+    expect(result.current.isPending).toBeDefined();
+    expect(result.current.isError).toBeDefined();
+  });
+
+  it('should handle mutation error', async () => {
+    addPreset.mockRejectedValue(new Error('Failed to add'));
+
+    const { result } = renderHook(() => useAddPreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(async () => {
+      await act(async () => {
+        await result.current.mutateAsync({ text: 'Test', type: 'income' });
+      });
+    }).rejects.toThrow('Failed to add');
+  });
+});
+
+describe('useUpdatePreset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should update a preset', async () => {
+    const updatedPreset = { id: 1, text: 'Updated Salary', type: 'income', isDefault: true, order: 0, createdAt: 1000 };
+    updatePreset.mockResolvedValue(updatedPreset);
+
+    const { result } = renderHook(() => useUpdatePreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: 1, updates: { text: 'Updated Salary' } });
+    });
+
+    expect(updatePreset).toHaveBeenCalledWith(1, { text: 'Updated Salary' });
+  });
+
+  it('should handle update error', async () => {
+    updatePreset.mockRejectedValue(new Error('Update failed'));
+
+    const { result } = renderHook(() => useUpdatePreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(async () => {
+      await act(async () => {
+        await result.current.mutateAsync({ id: 99, updates: { text: 'Nope' } });
+      });
+    }).rejects.toThrow('Update failed');
+  });
+});
+
+describe('useDeletePreset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete a preset by id', async () => {
+    deletePreset.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeletePreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(deletePreset).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle delete error', async () => {
+    deletePreset.mockRejectedValue(new Error('Delete failed'));
+
+    const { result } = renderHook(() => useDeletePreset(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(async () => {
+      await act(async () => {
+        await result.current.mutateAsync(99);
+      });
+    }).rejects.toThrow('Delete failed');
+  });
+});
+
+describe('useReorderPresets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call reorderPresets with the provided id array', async () => {
+    reorderPresets.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useReorderPresets(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync([3, 1, 2]);
+    });
+
+    expect(reorderPresets).toHaveBeenCalledWith([3, 1, 2]);
+  });
+
+  it('should handle reorder error', async () => {
+    reorderPresets.mockRejectedValue(new Error('Reorder failed'));
+
+    const { result } = renderHook(() => useReorderPresets(), {
+      wrapper: createWrapper(),
+    });
+
+    await expect(async () => {
+      await act(async () => {
+        await result.current.mutateAsync([1, 2]);
+      });
+    }).rejects.toThrow('Reorder failed');
+  });
+});
+
+describe('cache invalidation', () => {
+  it('should invalidate preset queries after addPreset mutation', async () => {
+    const newPreset = { id: 10, text: 'New', type: 'income', isDefault: false, order: 0, createdAt: 3000 };
+    addPreset.mockResolvedValue(newPreset);
+    getPresetsByType.mockResolvedValue([newPreset]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAddPreset(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ text: 'New', type: 'income' });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: presetQueryKeys.all })
+    );
+  });
+
+  it('should invalidate preset queries after deletePreset mutation', async () => {
+    deletePreset.mockResolvedValue(undefined);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useDeletePreset(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(1);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: presetQueryKeys.all })
+    );
+  });
+});

--- a/src/services/db.js
+++ b/src/services/db.js
@@ -13,9 +13,10 @@ import { openDB } from 'idb';
 import { validateEntry, getAccountingMonthFromDate } from './validation';
 
 const DB_NAME = 'maaser-tracker';
-const DB_VERSION = 3; // Bumped for settings store
+const DB_VERSION = 4; // Bumped for notePresets store
 const STORE_NAME = 'entries';
 const SETTINGS_STORE_NAME = 'settings';
+export const PRESETS_STORE_NAME = 'notePresets';
 
 /**
  * Initialize and open the IndexedDB database
@@ -57,6 +58,19 @@ export async function initDB() {
           db.createObjectStore(SETTINGS_STORE_NAME, { keyPath: 'id' });
           if (import.meta.env.DEV) {
             console.log('IndexedDB: Settings object store created');
+          }
+        }
+
+        // v4: Add notePresets object store
+        if (!db.objectStoreNames.contains(PRESETS_STORE_NAME)) {
+          const presetsStore = db.createObjectStore(PRESETS_STORE_NAME, {
+            keyPath: 'id',
+            autoIncrement: true,
+          });
+          presetsStore.createIndex('type', 'type', { unique: false });
+          presetsStore.createIndex('order', 'order', { unique: false });
+          if (import.meta.env.DEV) {
+            console.log('IndexedDB: notePresets object store created');
           }
         }
       },

--- a/src/services/presetService.js
+++ b/src/services/presetService.js
@@ -1,0 +1,285 @@
+/**
+ * Preset Service Layer for Ma'aser Tracker
+ *
+ * Manages note presets stored in the 'notePresets' IndexedDB object store.
+ * Presets are short text labels (e.g. "Salary", "Charity Dinner") that users
+ * can pick when entering income or donation records.
+ *
+ * Schema (notePresets store):
+ *   id        — auto-increment integer (keyPath)
+ *   text      — string
+ *   type      — 'income' | 'donation'
+ *   isDefault — boolean
+ *   order     — number (sort position within the same type)
+ *   createdAt — Unix timestamp (ms)
+ */
+
+import { initDB, PRESETS_STORE_NAME } from './db';
+
+// ─── Default presets ──────────────────────────────────────────────────────────
+
+export const DEFAULT_INCOME_PRESETS = [
+  { text: 'Salary', type: 'income', isDefault: true, order: 0 },
+  { text: 'Bonus', type: 'income', isDefault: true, order: 1 },
+  { text: 'Gift', type: 'income', isDefault: true, order: 2 },
+  { text: 'Freelance', type: 'income', isDefault: true, order: 3 },
+  { text: 'Investment', type: 'income', isDefault: true, order: 4 },
+  { text: 'Other', type: 'income', isDefault: true, order: 5 },
+];
+
+export const DEFAULT_DONATION_PRESETS = [
+  { text: 'Charity Dinner', type: 'donation', isDefault: true, order: 0 },
+  { text: 'Monthly Pledge', type: 'donation', isDefault: true, order: 1 },
+  { text: 'Synagogue', type: 'donation', isDefault: true, order: 2 },
+  { text: 'Food Bank', type: 'donation', isDefault: true, order: 3 },
+  { text: 'Emergency Relief', type: 'donation', isDefault: true, order: 4 },
+  { text: 'Other', type: 'donation', isDefault: true, order: 5 },
+];
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Get all presets for a given type, sorted by order ascending.
+ *
+ * @param {string} type - 'income' | 'donation'
+ * @returns {Promise<Array>} Presets sorted by order
+ */
+export async function getPresetsByType(type) {
+  try {
+    const db = await initDB();
+    const index = db.transaction(PRESETS_STORE_NAME).store.index('type');
+    const presets = await index.getAll(type);
+    return presets.sort((a, b) => a.order - b.order);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to get presets by type', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Add a new custom preset.
+ *
+ * @param {string} text - Preset label text
+ * @param {string} type - 'income' | 'donation'
+ * @returns {Promise<Object>} The stored preset (including auto-assigned id)
+ */
+export async function addPreset(text, type) {
+  try {
+    const db = await initDB();
+    const existing = await getPresetsByType(type);
+    const maxOrder = existing.length > 0 ? Math.max(...existing.map((p) => p.order)) : -1;
+
+    const preset = {
+      text,
+      type,
+      isDefault: false,
+      order: maxOrder + 1,
+      createdAt: Date.now(),
+    };
+
+    const id = await db.add(PRESETS_STORE_NAME, preset);
+    const stored = { ...preset, id };
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Preset added', id);
+    }
+
+    return stored;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to add preset', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Update fields of an existing preset.
+ *
+ * @param {number} id - Preset id (auto-increment key)
+ * @param {Object} updates - Partial preset fields to apply
+ * @returns {Promise<Object>} The updated preset
+ * @throws {Error} If the preset does not exist
+ */
+export async function updatePreset(id, updates) {
+  try {
+    const db = await initDB();
+    const existing = await db.get(PRESETS_STORE_NAME, id);
+
+    if (!existing) {
+      throw new Error(`Preset not found: ${id}`);
+    }
+
+    const updated = { ...existing, ...updates, id };
+    await db.put(PRESETS_STORE_NAME, updated);
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Preset updated', id);
+    }
+
+    return updated;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to update preset', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Delete a preset by id.
+ * No-op if the preset does not exist.
+ *
+ * @param {number} id - Preset id
+ * @returns {Promise<void>}
+ */
+export async function deletePreset(id) {
+  try {
+    const db = await initDB();
+    await db.delete(PRESETS_STORE_NAME, id);
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Preset deleted', id);
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to delete preset', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reorder presets by assigning each id a new order value equal to its index
+ * in the provided array.
+ *
+ * @param {number[]} presetIds - Ordered list of preset ids (first = order 0)
+ * @returns {Promise<void>}
+ */
+export async function reorderPresets(presetIds) {
+  if (!presetIds || presetIds.length === 0) {
+    return;
+  }
+
+  try {
+    const db = await initDB();
+    const tx = db.transaction(PRESETS_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(PRESETS_STORE_NAME);
+
+    for (let i = 0; i < presetIds.length; i++) {
+      const id = presetIds[i];
+      const preset = await store.get(id);
+      if (preset) {
+        await store.put({ ...preset, order: i });
+      }
+    }
+
+    await tx.done;
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Presets reordered', presetIds);
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to reorder presets', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Initialize default presets on first launch.
+ * Checks if any presets exist; if none, inserts all defaults.
+ * Safe to call on every app startup — idempotent.
+ *
+ * @returns {Promise<void>}
+ */
+export async function initializeDefaultPresets() {
+  try {
+    const db = await initDB();
+    const count = await db.count(PRESETS_STORE_NAME);
+
+    if (count > 0) {
+      // Already initialized
+      return;
+    }
+
+    const allDefaults = [...DEFAULT_INCOME_PRESETS, ...DEFAULT_DONATION_PRESETS];
+    const now = Date.now();
+
+    const tx = db.transaction(PRESETS_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(PRESETS_STORE_NAME);
+
+    for (const preset of allDefaults) {
+      await store.add({ ...preset, createdAt: now });
+    }
+
+    await tx.done;
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Default presets initialized');
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to initialize default presets', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Reset presets to defaults.
+ * Clears all existing presets and re-inserts the defaults.
+ *
+ * @returns {Promise<void>}
+ */
+export async function resetDefaultPresets() {
+  try {
+    await clearAllPresets();
+    const db = await initDB();
+    const allDefaults = [...DEFAULT_INCOME_PRESETS, ...DEFAULT_DONATION_PRESETS];
+    const now = Date.now();
+
+    const tx = db.transaction(PRESETS_STORE_NAME, 'readwrite');
+    const store = tx.objectStore(PRESETS_STORE_NAME);
+
+    for (const preset of allDefaults) {
+      await store.add({ ...preset, createdAt: now });
+    }
+
+    await tx.done;
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: Default presets restored');
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to reset default presets', error);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Clear all presets from the store.
+ * Primarily used in tests; also called by resetDefaultPresets.
+ *
+ * @returns {Promise<void>}
+ */
+export async function clearAllPresets() {
+  try {
+    const db = await initDB();
+    await db.clear(PRESETS_STORE_NAME);
+
+    if (import.meta.env.DEV) {
+      console.log('PresetService: All presets cleared');
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('PresetService: Failed to clear presets', error);
+    }
+    throw error;
+  }
+}

--- a/src/services/presetService.test.js
+++ b/src/services/presetService.test.js
@@ -1,0 +1,336 @@
+/**
+ * Tests for Preset Service Layer
+ *
+ * Covers CRUD operations, default preset initialization,
+ * type filtering, reordering, and reset functionality.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getPresetsByType,
+  addPreset,
+  updatePreset,
+  deletePreset,
+  reorderPresets,
+  initializeDefaultPresets,
+  resetDefaultPresets,
+  DEFAULT_INCOME_PRESETS,
+  DEFAULT_DONATION_PRESETS,
+  clearAllPresets,
+} from './presetService';
+
+describe('Preset Service', () => {
+  beforeEach(async () => {
+    await clearAllPresets();
+  });
+
+  afterEach(async () => {
+    await clearAllPresets();
+  });
+
+  describe('DEFAULT_INCOME_PRESETS', () => {
+    it('should contain the expected income preset texts', () => {
+      const texts = DEFAULT_INCOME_PRESETS.map((p) => p.text);
+      expect(texts).toContain('Salary');
+      expect(texts).toContain('Bonus');
+      expect(texts).toContain('Gift');
+      expect(texts).toContain('Freelance');
+      expect(texts).toContain('Investment');
+      expect(texts).toContain('Other');
+    });
+
+    it('should have isDefault set to true for all income presets', () => {
+      DEFAULT_INCOME_PRESETS.forEach((p) => {
+        expect(p.isDefault).toBe(true);
+      });
+    });
+
+    it('should have type income for all default income presets', () => {
+      DEFAULT_INCOME_PRESETS.forEach((p) => {
+        expect(p.type).toBe('income');
+      });
+    });
+
+    it('should have a sequential order field', () => {
+      const orders = DEFAULT_INCOME_PRESETS.map((p) => p.order);
+      orders.forEach((order, index) => {
+        expect(order).toBe(index);
+      });
+    });
+  });
+
+  describe('DEFAULT_DONATION_PRESETS', () => {
+    it('should contain the expected donation preset texts', () => {
+      const texts = DEFAULT_DONATION_PRESETS.map((p) => p.text);
+      expect(texts).toContain('Charity Dinner');
+      expect(texts).toContain('Monthly Pledge');
+      expect(texts).toContain('Synagogue');
+      expect(texts).toContain('Food Bank');
+      expect(texts).toContain('Emergency Relief');
+      expect(texts).toContain('Other');
+    });
+
+    it('should have isDefault set to true for all donation presets', () => {
+      DEFAULT_DONATION_PRESETS.forEach((p) => {
+        expect(p.isDefault).toBe(true);
+      });
+    });
+
+    it('should have type donation for all default donation presets', () => {
+      DEFAULT_DONATION_PRESETS.forEach((p) => {
+        expect(p.type).toBe('donation');
+      });
+    });
+  });
+
+  describe('initializeDefaultPresets', () => {
+    it('should insert default income and donation presets on first call', async () => {
+      await initializeDefaultPresets();
+
+      const incomePresets = await getPresetsByType('income');
+      const donationPresets = await getPresetsByType('donation');
+
+      expect(incomePresets.length).toBe(DEFAULT_INCOME_PRESETS.length);
+      expect(donationPresets.length).toBe(DEFAULT_DONATION_PRESETS.length);
+    });
+
+    it('should not insert duplicates when called twice', async () => {
+      await initializeDefaultPresets();
+      await initializeDefaultPresets();
+
+      const incomePresets = await getPresetsByType('income');
+      expect(incomePresets.length).toBe(DEFAULT_INCOME_PRESETS.length);
+    });
+
+    it('should mark inserted presets as isDefault true', async () => {
+      await initializeDefaultPresets();
+
+      const incomePresets = await getPresetsByType('income');
+      incomePresets.forEach((p) => {
+        expect(p.isDefault).toBe(true);
+      });
+    });
+
+    it('should set a createdAt timestamp on each preset', async () => {
+      await initializeDefaultPresets();
+
+      const presets = await getPresetsByType('income');
+      presets.forEach((p) => {
+        expect(p.createdAt).toBeDefined();
+        expect(typeof p.createdAt).toBe('number');
+      });
+    });
+  });
+
+  describe('getPresetsByType', () => {
+    beforeEach(async () => {
+      await initializeDefaultPresets();
+    });
+
+    it('should return only income presets when type is income', async () => {
+      const presets = await getPresetsByType('income');
+      presets.forEach((p) => expect(p.type).toBe('income'));
+    });
+
+    it('should return only donation presets when type is donation', async () => {
+      const presets = await getPresetsByType('donation');
+      presets.forEach((p) => expect(p.type).toBe('donation'));
+    });
+
+    it('should return presets sorted by order ascending', async () => {
+      const presets = await getPresetsByType('income');
+      for (let i = 1; i < presets.length; i++) {
+        expect(presets[i].order).toBeGreaterThanOrEqual(presets[i - 1].order);
+      }
+    });
+
+    it('should return empty array for unknown type', async () => {
+      const presets = await getPresetsByType('unknown');
+      expect(presets).toEqual([]);
+    });
+
+    it('should return empty array when no presets exist', async () => {
+      await clearAllPresets();
+      const presets = await getPresetsByType('income');
+      expect(presets).toEqual([]);
+    });
+  });
+
+  describe('addPreset', () => {
+    it('should add a new income preset and return the full preset object', async () => {
+      const preset = await addPreset('Consulting', 'income');
+
+      expect(preset).toBeDefined();
+      expect(preset.id).toBeDefined();
+      expect(preset.text).toBe('Consulting');
+      expect(preset.type).toBe('income');
+      expect(preset.isDefault).toBe(false);
+      expect(typeof preset.order).toBe('number');
+      expect(typeof preset.createdAt).toBe('number');
+    });
+
+    it('should add a new donation preset', async () => {
+      const preset = await addPreset('Local Shelter', 'donation');
+
+      expect(preset.text).toBe('Local Shelter');
+      expect(preset.type).toBe('donation');
+    });
+
+    it('should persist the preset so it appears in getPresetsByType', async () => {
+      await addPreset('Consulting', 'income');
+
+      const presets = await getPresetsByType('income');
+      const found = presets.find((p) => p.text === 'Consulting');
+      expect(found).toBeDefined();
+    });
+
+    it('should append preset at the end (highest order)', async () => {
+      await initializeDefaultPresets();
+
+      const beforePresets = await getPresetsByType('income');
+      const maxOrderBefore = Math.max(...beforePresets.map((p) => p.order));
+
+      const newPreset = await addPreset('Side Hustle', 'income');
+      expect(newPreset.order).toBeGreaterThan(maxOrderBefore);
+    });
+
+    it('should assign order 0 when no presets of that type exist', async () => {
+      const preset = await addPreset('First Preset', 'income');
+      expect(preset.order).toBe(0);
+    });
+  });
+
+  describe('updatePreset', () => {
+    it('should update the text of an existing preset', async () => {
+      const created = await addPreset('Old Text', 'income');
+      const updated = await updatePreset(created.id, { text: 'New Text' });
+
+      expect(updated.text).toBe('New Text');
+      expect(updated.id).toBe(created.id);
+      expect(updated.type).toBe('income');
+    });
+
+    it('should update the order of a preset', async () => {
+      const created = await addPreset('Test Preset', 'income');
+      const updated = await updatePreset(created.id, { order: 99 });
+
+      expect(updated.order).toBe(99);
+    });
+
+    it('should persist updates so they appear in getPresetsByType', async () => {
+      const created = await addPreset('Old Text', 'income');
+      await updatePreset(created.id, { text: 'Updated Text' });
+
+      const presets = await getPresetsByType('income');
+      const found = presets.find((p) => p.id === created.id);
+      expect(found.text).toBe('Updated Text');
+    });
+
+    it('should throw when preset id does not exist', async () => {
+      await expect(updatePreset(99999, { text: 'Nope' })).rejects.toThrow();
+    });
+
+    it('should preserve fields not included in updates', async () => {
+      const created = await addPreset('My Preset', 'income');
+      const updated = await updatePreset(created.id, { text: 'Updated' });
+
+      expect(updated.type).toBe('income');
+      expect(updated.isDefault).toBe(false);
+      expect(updated.createdAt).toBe(created.createdAt);
+    });
+  });
+
+  describe('deletePreset', () => {
+    it('should remove the preset from the store', async () => {
+      const created = await addPreset('To Delete', 'income');
+      await deletePreset(created.id);
+
+      const presets = await getPresetsByType('income');
+      const found = presets.find((p) => p.id === created.id);
+      expect(found).toBeUndefined();
+    });
+
+    it('should not throw when deleting a non-existent id', async () => {
+      await expect(deletePreset(99999)).resolves.not.toThrow();
+    });
+
+    it('should only remove the targeted preset, not others', async () => {
+      const a = await addPreset('Keep This', 'income');
+      const b = await addPreset('Delete This', 'income');
+
+      await deletePreset(b.id);
+
+      const presets = await getPresetsByType('income');
+      expect(presets.find((p) => p.id === a.id)).toBeDefined();
+      expect(presets.find((p) => p.id === b.id)).toBeUndefined();
+    });
+  });
+
+  describe('reorderPresets', () => {
+    it('should update order of each preset based on its array index', async () => {
+      const a = await addPreset('A', 'income');
+      const b = await addPreset('B', 'income');
+      const c = await addPreset('C', 'income');
+
+      // Reverse the order
+      await reorderPresets([c.id, b.id, a.id]);
+
+      const presets = await getPresetsByType('income');
+      const updatedA = presets.find((p) => p.id === a.id);
+      const updatedB = presets.find((p) => p.id === b.id);
+      const updatedC = presets.find((p) => p.id === c.id);
+
+      expect(updatedC.order).toBe(0);
+      expect(updatedB.order).toBe(1);
+      expect(updatedA.order).toBe(2);
+    });
+
+    it('should sort by the new order after reordering', async () => {
+      const a = await addPreset('A', 'income');
+      const b = await addPreset('B', 'income');
+      const c = await addPreset('C', 'income');
+
+      await reorderPresets([c.id, a.id, b.id]);
+
+      const presets = await getPresetsByType('income');
+      expect(presets[0].id).toBe(c.id);
+      expect(presets[1].id).toBe(a.id);
+      expect(presets[2].id).toBe(b.id);
+    });
+
+    it('should handle empty array without error', async () => {
+      await expect(reorderPresets([])).resolves.not.toThrow();
+    });
+  });
+
+  describe('resetDefaultPresets', () => {
+    it('should delete all existing presets and re-insert defaults', async () => {
+      await initializeDefaultPresets();
+      await addPreset('Custom Preset', 'income');
+
+      await resetDefaultPresets();
+
+      const incomePresets = await getPresetsByType('income');
+      const hasCustom = incomePresets.some((p) => p.text === 'Custom Preset');
+      expect(hasCustom).toBe(false);
+      expect(incomePresets.length).toBe(DEFAULT_INCOME_PRESETS.length);
+    });
+
+    it('should restore default donation presets too', async () => {
+      await initializeDefaultPresets();
+      await addPreset('Custom Donation', 'donation');
+
+      await resetDefaultPresets();
+
+      const donationPresets = await getPresetsByType('donation');
+      expect(donationPresets.length).toBe(DEFAULT_DONATION_PRESETS.length);
+    });
+
+    it('should work even when called on an empty store', async () => {
+      await expect(resetDefaultPresets()).resolves.not.toThrow();
+
+      const incomePresets = await getPresetsByType('income');
+      expect(incomePresets.length).toBe(DEFAULT_INCOME_PRESETS.length);
+    });
+  });
+});

--- a/src/services/settingsDb.test.js
+++ b/src/services/settingsDb.test.js
@@ -408,7 +408,7 @@ describe('Settings DB Service', () => {
 
     it('should have the correct database version', async () => {
       const db = await initDB();
-      expect(db.version).toBe(3);
+      expect(db.version).toBe(4);
     });
 
     it('should allow settings operations alongside entry operations', async () => {


### PR DESCRIPTION
Closes #211

## Summary

Service layer for notes presets: IndexedDB CRUD operations and React Query hooks.

## Validation Results

- **Tests:** 52/52 passing (all green)
- **Lint:** 0 errors, 0 warnings
- **Code review:** Syntax + security clean

## Checklist
- [x] Tests passing (52/52)
- [x] Lint clean
- [x] Code review (syntax + security)
- [ ] CI green (N/A — CI triggers on PRs to `develop`; this PR targets `epic/43-notes-presets`)

> **Note:** The CI workflow (`ci.yml`) only runs on pull requests targeting `develop`. This sub-issue PR targets the epic branch `epic/43-notes-presets`. Local validation was performed: 52/52 tests pass, lint is clean, and code review found no issues. CI will run when the epic branch is promoted to `develop`.