### PR TITLE
#214 Form Integration + Translations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,6 +53,7 @@ import { queryClient } from './lib/queryClient';
 import { useEntries, useAddEntry, useUpdateEntry, useDeleteEntry } from './hooks/useEntries';
 import { isIndexedDBSupported } from './services/db';
 import { migrateFromLocalStorage, createLocalStorageBackup } from './services/migration';
+import { initializeDefaultPresets } from './services/presetService';
 
 // Hash routing via useSyncExternalStore (no setState in useEffect)
 function subscribeToHash(callback) {
@@ -178,6 +179,16 @@ function MainApp({ theme, cacheRtl }) {
 
     runMigration();
   }, [indexedDBSupported, showSuccess]);
+
+  // Initialize default presets on first launch (idempotent — no-op if already initialized)
+  useEffect(() => {
+    if (!indexedDBSupported) {
+      return;
+    }
+    initializeDefaultPresets().catch(() => {
+      // Silently ignore — presets are non-critical; app works without them
+    });
+  }, [indexedDBSupported]);
 
   const handleAddEntry = useCallback((entry) => {
     const existingEntry = entries.find((e) => e.id === entry.id);

--- a/src/App.presets.test.jsx
+++ b/src/App.presets.test.jsx
@@ -1,0 +1,198 @@
+/**
+ * Tests: initializeDefaultPresets called on App mount
+ *
+ * Tests that the hook/effect that initializes presets is called.
+ * We test this via the MainApp's internal useEffect by mocking the service.
+ *
+ * Strategy: render just the component that contains the useEffect
+ * (MainApp via App) with all heavy dependencies mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ─── Mock everything that App imports ─────────────────────────────────────────
+
+// Mock presetService BEFORE importing App
+vi.mock('./services/presetService', () => ({
+  initializeDefaultPresets: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock firebase.js so it doesn't throw
+vi.mock('./lib/firebase', () => ({
+  auth: {},
+  db: {},
+}));
+
+// Mock firebase/app
+vi.mock('firebase/app', () => ({
+  initializeApp: vi.fn(() => ({})),
+}));
+
+// Mock firebase/auth — include all functions used
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({})),
+  onAuthStateChanged: vi.fn((_auth, cb) => {
+    cb(null); // unauthenticated
+    return () => {};
+  }),
+  GoogleAuthProvider: vi.fn(function () {}),
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// Mock firebase/firestore
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  collection: vi.fn(),
+  doc: vi.fn(),
+  getDocs: vi.fn().mockResolvedValue({ docs: [] }),
+  setDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+}));
+
+// Mock IndexedDB services
+vi.mock('./services/db', () => ({
+  isIndexedDBSupported: vi.fn(() => true),
+  getAllEntries: vi.fn().mockResolvedValue([]),
+  addEntry: vi.fn(),
+  updateEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+  initDB: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('./services/migration', () => ({
+  migrateFromLocalStorage: vi.fn().mockResolvedValue({ success: true, entriesMigrated: 0 }),
+  createLocalStorageBackup: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('./hooks/useEntries', () => ({
+  useEntries: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+  useAddEntry: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useUpdateEntry: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useDeleteEntry: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('./hooks/useSettings', () => ({
+  useSettings: vi.fn().mockReturnValue({
+    settings: { language: 'en', currency: 'ILS', themeMode: 'system', maaserPercentagePeriods: [{ percentage: 10, effectiveFrom: '2020-01-01' }] },
+    isLoading: false,
+    getCurrentMaaserPercentage: () => 10,
+    formatCurrency: (v) => `₪${v}`,
+  }),
+}));
+
+vi.mock('./contexts/SettingsProvider', () => ({
+  SettingsProvider: ({ children }) => children,
+}));
+
+vi.mock('./contexts/AuthProvider', () => ({
+  AuthProvider: ({ children }) => children,
+}));
+
+vi.mock('./hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: false, user: null }),
+}));
+
+vi.mock('./contexts/LanguageProvider', () => ({
+  LanguageProvider: ({ children }) => children,
+}));
+
+vi.mock('./contexts/useLanguage', () => ({
+  useLanguage: () => ({
+    t: {
+      appName: 'Test',
+      dashboard: 'Dashboard',
+      addIncome: 'Add Income',
+      addDonation: 'Add Donation',
+      history: 'History',
+      backOnline: 'Back online',
+      migrationComplete: 'Done',
+      migrationCancelled: 'Cancelled',
+    },
+    direction: 'ltr',
+  }),
+}));
+
+vi.mock('./theme', () => ({
+  createAppTheme: vi.fn(() => ({})),
+}));
+
+// Mock all MUI theming to avoid theme.typography errors
+vi.mock('@mui/material', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    ThemeProvider: ({ children }) => children,
+    CssBaseline: () => null,
+  };
+});
+
+vi.mock('./hooks/useResolvedTheme', () => ({
+  useResolvedTheme: vi.fn(() => 'light'),
+}));
+
+// Mock MUI-heavy components to avoid rendering complexity
+vi.mock('./components/Dashboard', () => ({ default: () => <div>Dashboard</div> }));
+vi.mock('./components/AddIncome', () => ({ default: () => <div>AddIncome</div> }));
+vi.mock('./components/AddDonation', () => ({ default: () => <div>AddDonation</div> }));
+vi.mock('./components/History', () => ({ default: () => <div>History</div> }));
+vi.mock('./components/SettingsPage', () => ({ default: () => <div>Settings</div> }));
+vi.mock('./components/SettingsButton', () => ({ default: () => <div>SettingsButton</div> }));
+vi.mock('./components/LanguageToggle', () => ({ default: () => <div>LanguageToggle</div> }));
+vi.mock('./components/SignInButton', () => ({ default: () => <div>SignIn</div> }));
+vi.mock('./components/UserProfile', () => ({ default: () => <div>UserProfile</div> }));
+vi.mock('./components/PrivacyPolicy', () => ({ default: () => <div>Privacy</div> }));
+vi.mock('./components/ErrorBoundary', () => ({
+  IndexedDBUnavailable: () => <div>Error</div>,
+  MigrationError: () => <div>MigError</div>,
+  LoadingState: () => <div>Loading</div>,
+}));
+vi.mock('./components/InstallPrompt', () => ({ default: () => null }));
+vi.mock('./components/ConnectionStatus', () => ({ default: () => null }));
+vi.mock('./components/MigrationPrompt', () => ({ default: () => null }));
+
+vi.mock('./lib/queryClient', () => ({
+  queryClient: new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  }),
+}));
+
+vi.mock('@emotion/react', () => ({
+  CacheProvider: ({ children }) => children,
+}));
+vi.mock('@emotion/cache', () => ({ default: vi.fn(() => ({})) }));
+vi.mock('stylis-plugin-rtl', () => ({ default: vi.fn() }));
+vi.mock('stylis', () => ({ prefixer: vi.fn() }));
+
+// ─── Import under test ────────────────────────────────────────────────────────
+import App from './App';
+import { initializeDefaultPresets } from './services/presetService';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('App — initializeDefaultPresets on mount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call initializeDefaultPresets when the app mounts', async () => {
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(initializeDefaultPresets).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call initializeDefaultPresets only once', async () => {
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(initializeDefaultPresets).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/AddDonation.jsx
+++ b/src/components/AddDonation.jsx
@@ -11,6 +11,8 @@ import {
 import { useLanguage } from '../contexts/useLanguage';
 import { format } from 'date-fns';
 import { NOTE_MAX_LENGTH, NOTE_WARN_THRESHOLD, getAccountingMonthFromDate } from '../services/validation';
+import NotePresetButtons from './NotePresetButtons';
+import PresetManagementDialog from './PresetManagementDialog';
 
 export default function AddDonation({ onAdd, editEntry, onCancel }) {
   const { t } = useLanguage();
@@ -24,6 +26,7 @@ export default function AddDonation({ onAdd, editEntry, onCancel }) {
   const [note, setNote] = useState(editEntry ? (editEntry.note || '') : '');
   const [error, setError] = useState('');
   const [noteError, setNoteError] = useState('');
+  const [showPresetDialog, setShowPresetDialog] = useState(false);
 
   const handleNoteChange = (e) => {
     const value = e.target.value;
@@ -132,7 +135,7 @@ export default function AddDonation({ onAdd, editEntry, onCancel }) {
             placeholder={t.noteOptional}
             error={!!noteError}
             helperText={noteError || `${note.length} / ${NOTE_MAX_LENGTH}`}
-            sx={{ mb: 3 }}
+            sx={{ mb: 1 }}
             inputProps={{ maxLength: NOTE_MAX_LENGTH + 1 }}
             slotProps={{
               formHelperText: {
@@ -148,7 +151,18 @@ export default function AddDonation({ onAdd, editEntry, onCancel }) {
               },
             }}
           />
-          <Box sx={{ display: 'flex', gap: 2 }}>
+          <NotePresetButtons
+            type="donation"
+            onSelect={(text) => setNote(text)}
+            selectedText={note}
+            onManageClick={() => setShowPresetDialog(true)}
+          />
+          <PresetManagementDialog
+            open={showPresetDialog}
+            onClose={() => setShowPresetDialog(false)}
+            type="donation"
+          />
+          <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
             <Button
               fullWidth
               variant="contained"

--- a/src/components/AddDonation.presets.test.jsx
+++ b/src/components/AddDonation.presets.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * Integration Tests: AddDonation + NotePresetButtons
+ *
+ * Tests cover:
+ * - NotePresetButtons renders below the notes field
+ * - Tapping a preset chip fills the notes field
+ * - [+] button opens PresetManagementDialog
+ * - type='donation' is passed to NotePresetButtons
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '../test/utils';
+import userEvent from '@testing-library/user-event';
+import AddDonation from './AddDonation';
+
+// Mock NotePresetButtons to isolate AddDonation behavior
+vi.mock('./NotePresetButtons', () => ({
+  default: ({ type, onSelect, selectedText, onManageClick }) => (
+    <div data-testid="note-preset-buttons" data-type={type} data-selected={selectedText}>
+      <button
+        data-testid="preset-chip-charity"
+        onClick={() => onSelect('Charity Dinner')}
+      >
+        Charity Dinner
+      </button>
+      <button
+        data-testid="preset-manage-btn"
+        onClick={onManageClick}
+      >
+        +
+      </button>
+    </div>
+  ),
+}));
+
+// Mock PresetManagementDialog
+vi.mock('./PresetManagementDialog', () => ({
+  default: ({ open, onClose, type }) => (
+    open ? (
+      <div
+        role="dialog"
+        data-testid="preset-management-dialog"
+        data-type={type}
+      >
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null
+  ),
+}));
+
+vi.stubGlobal('crypto', {
+  randomUUID: vi.fn(() => 'test-uuid-donation-preset'),
+});
+
+describe('AddDonation + NotePresetButtons integration', () => {
+  let onAdd;
+
+  beforeEach(() => {
+    onAdd = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  it('should render NotePresetButtons below the notes field', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toBeInTheDocument();
+  });
+
+  it('should pass type="donation" to NotePresetButtons', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-type', 'donation');
+  });
+
+  it('should fill the notes field when a preset chip is tapped', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const chip = screen.getByTestId('preset-chip-charity');
+    fireEvent.click(chip);
+
+    const noteField = screen.getByLabelText(/note|הערה/i);
+    expect(noteField.value).toBe('Charity Dinner');
+  });
+
+  it('should pass selectedText (current note value) to NotePresetButtons', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-selected', '');
+  });
+
+  it('should open PresetManagementDialog when [+] is clicked', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const manageBtn = screen.getByTestId('preset-manage-btn');
+    fireEvent.click(manageBtn);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('preset-management-dialog')).toBeInTheDocument();
+  });
+
+  it('should pass type="donation" to PresetManagementDialog', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const manageBtn = screen.getByTestId('preset-manage-btn');
+    fireEvent.click(manageBtn);
+
+    const dialog = screen.getByTestId('preset-management-dialog');
+    expect(dialog).toHaveAttribute('data-type', 'donation');
+  });
+
+  it('should close PresetManagementDialog when its onClose is called', async () => {
+    const user = userEvent.setup();
+    render(<AddDonation onAdd={onAdd} />);
+
+    // Open dialog
+    fireEvent.click(screen.getByTestId('preset-manage-btn'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Close dialog
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    await user.click(closeBtn);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should submit the preset-filled note when form is saved', async () => {
+    const user = userEvent.setup();
+    render(<AddDonation onAdd={onAdd} />);
+
+    // Fill amount using fireEvent for speed
+    const amountInput = screen.getByLabelText(/amount|סכום/i);
+    fireEvent.change(amountInput, { target: { value: '500' } });
+
+    // Click preset chip
+    const chip = screen.getByTestId('preset-chip-charity');
+    fireEvent.click(chip);
+
+    // Submit form
+    const saveBtn = screen.getByRole('button', { name: /save|שמור/i });
+    await user.click(saveBtn);
+
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        note: 'Charity Dinner',
+        type: 'donation',
+      })
+    );
+  });
+
+  it('should update selectedText in NotePresetButtons when note changes manually', () => {
+    render(<AddDonation onAdd={onAdd} />);
+
+    const noteField = screen.getByLabelText(/note|הערה/i);
+    fireEvent.change(noteField, { target: { value: 'Custom donation' } });
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-selected', 'Custom donation');
+  });
+});

--- a/src/components/AddIncome.jsx
+++ b/src/components/AddIncome.jsx
@@ -12,6 +12,8 @@ import { useLanguage } from '../contexts/useLanguage';
 import { useSettings } from '../hooks/useSettings';
 import { format } from 'date-fns';
 import { NOTE_MAX_LENGTH, NOTE_WARN_THRESHOLD, getAccountingMonthFromDate } from '../services/validation';
+import NotePresetButtons from './NotePresetButtons';
+import PresetManagementDialog from './PresetManagementDialog';
 
 export default function AddIncome({ onAdd, editEntry, onCancel }) {
   const { t } = useLanguage();
@@ -29,6 +31,7 @@ export default function AddIncome({ onAdd, editEntry, onCancel }) {
   const [note, setNote] = useState(editEntry ? (editEntry.note || '') : '');
   const [error, setError] = useState('');
   const [noteError, setNoteError] = useState('');
+  const [showPresetDialog, setShowPresetDialog] = useState(false);
 
   // Currency symbol for input adornment
   const currencySymbols = { ILS: '₪', USD: '$', EUR: '€', GBP: '£' };
@@ -144,7 +147,7 @@ export default function AddIncome({ onAdd, editEntry, onCancel }) {
             placeholder={t.noteOptional}
             error={!!noteError}
             helperText={noteError || `${note.length} / ${NOTE_MAX_LENGTH}`}
-            sx={{ mb: 2 }}
+            sx={{ mb: 1 }}
             inputProps={{ maxLength: NOTE_MAX_LENGTH + 1 }}
             slotProps={{
               formHelperText: {
@@ -160,12 +163,24 @@ export default function AddIncome({ onAdd, editEntry, onCancel }) {
               },
             }}
           />
+          <NotePresetButtons
+            type="income"
+            onSelect={(text) => setNote(text)}
+            selectedText={note}
+            onManageClick={() => setShowPresetDialog(true)}
+          />
+          <PresetManagementDialog
+            open={showPresetDialog}
+            onClose={() => setShowPresetDialog(false)}
+            type="income"
+          />
           <Box
             sx={{
               bgcolor: 'primary.main',
               color: 'white',
               p: 2,
               borderRadius: 2,
+              mt: 2,
               mb: 3,
               textAlign: 'center',
             }}

--- a/src/components/AddIncome.presets.test.jsx
+++ b/src/components/AddIncome.presets.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * Integration Tests: AddIncome + NotePresetButtons
+ *
+ * Tests cover:
+ * - NotePresetButtons renders below the notes field
+ * - Tapping a preset chip fills the notes field
+ * - [+] button opens PresetManagementDialog
+ * - type='income' is passed to NotePresetButtons
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '../test/utils';
+import userEvent from '@testing-library/user-event';
+import AddIncome from './AddIncome';
+
+// Mock useSettings
+vi.mock('../hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: {
+      language: 'he',
+      currency: 'ILS',
+      maaserPercentagePeriods: [{ percentage: 10, effectiveFrom: '2020-01-01' }],
+      themeMode: 'system',
+    },
+    isLoading: false,
+    formatCurrency: (amount) => `₪${amount.toFixed(2)}`,
+    getCurrentMaaserPercentage: () => 10,
+    getMaaserPercentageForDate: () => 10,
+  }),
+}));
+
+// Mock NotePresetButtons to isolate AddIncome behavior
+vi.mock('./NotePresetButtons', () => ({
+  default: ({ type, onSelect, selectedText, onManageClick }) => (
+    <div data-testid="note-preset-buttons" data-type={type} data-selected={selectedText}>
+      <button
+        data-testid="preset-chip-salary"
+        onClick={() => onSelect('Salary')}
+      >
+        Salary
+      </button>
+      <button
+        data-testid="preset-manage-btn"
+        onClick={onManageClick}
+      >
+        +
+      </button>
+    </div>
+  ),
+}));
+
+// Mock PresetManagementDialog
+vi.mock('./PresetManagementDialog', () => ({
+  default: ({ open, onClose, type }) => (
+    open ? (
+      <div
+        role="dialog"
+        data-testid="preset-management-dialog"
+        data-type={type}
+      >
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null
+  ),
+}));
+
+vi.stubGlobal('crypto', {
+  randomUUID: vi.fn(() => 'test-uuid-preset'),
+});
+
+describe('AddIncome + NotePresetButtons integration', () => {
+  let onAdd;
+
+  beforeEach(() => {
+    onAdd = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  it('should render NotePresetButtons below the notes field', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toBeInTheDocument();
+  });
+
+  it('should pass type="income" to NotePresetButtons', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-type', 'income');
+  });
+
+  it('should fill the notes field when a preset chip is tapped', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const chip = screen.getByTestId('preset-chip-salary');
+    fireEvent.click(chip);
+
+    const noteField = screen.getByLabelText(/note|הערה/i);
+    expect(noteField.value).toBe('Salary');
+  });
+
+  it('should pass selectedText (current note value) to NotePresetButtons', async () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    // The selectedText should initially be empty
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-selected', '');
+  });
+
+  it('should open PresetManagementDialog when [+] is clicked', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const manageBtn = screen.getByTestId('preset-manage-btn');
+    fireEvent.click(manageBtn);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('preset-management-dialog')).toBeInTheDocument();
+  });
+
+  it('should pass type="income" to PresetManagementDialog', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const manageBtn = screen.getByTestId('preset-manage-btn');
+    fireEvent.click(manageBtn);
+
+    const dialog = screen.getByTestId('preset-management-dialog');
+    expect(dialog).toHaveAttribute('data-type', 'income');
+  });
+
+  it('should close PresetManagementDialog when its onClose is called', async () => {
+    const user = userEvent.setup();
+    render(<AddIncome onAdd={onAdd} />);
+
+    // Open dialog
+    fireEvent.click(screen.getByTestId('preset-manage-btn'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Close dialog
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    await user.click(closeBtn);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should submit the preset-filled note when form is saved', async () => {
+    const user = userEvent.setup();
+    render(<AddIncome onAdd={onAdd} />);
+
+    // Fill amount using fireEvent for speed
+    const amountInput = screen.getByLabelText(/amount|סכום/i);
+    fireEvent.change(amountInput, { target: { value: '1000' } });
+
+    // Click preset chip
+    const chip = screen.getByTestId('preset-chip-salary');
+    fireEvent.click(chip);
+
+    // Submit form
+    const saveBtn = screen.getByRole('button', { name: /save|שמור/i });
+    await user.click(saveBtn);
+
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        note: 'Salary',
+        type: 'income',
+      })
+    );
+  });
+
+  it('should update selectedText in NotePresetButtons when note changes manually', () => {
+    render(<AddIncome onAdd={onAdd} />);
+
+    const noteField = screen.getByLabelText(/note|הערה/i);
+    fireEvent.change(noteField, { target: { value: 'Custom note' } });
+
+    const presetButtons = screen.getByTestId('note-preset-buttons');
+    expect(presetButtons).toHaveAttribute('data-selected', 'Custom note');
+  });
+});

--- a/src/contexts/LanguageProvider.jsx
+++ b/src/contexts/LanguageProvider.jsx
@@ -491,6 +491,26 @@ const translations = {
         externalCsvHelp: 'נראה שקובץ ה-CSV שלך הגיע ממקור חיצוני (למשל Google Sheets). נעזור לך למפות את העמודות כדי לייבא את הנתונים.',
       },
     },
+
+    // Note Presets
+    presets: {
+      managePresetsTitle: 'ניהול תבניות',
+      addPresetPlaceholder: 'תבנית חדשה...',
+      add: 'הוסף',
+      editPreset: 'ערוך תבנית',
+      deletePreset: 'מחק תבנית',
+      defaultBadge: 'ברירת מחדל',
+      resetDefaults: 'אפס ברירות מחדל',
+      confirmDeleteTitle: 'מחיקת תבנית?',
+      confirmDeleteMessage: 'האם אתה בטוח שברצונך למחוק תבנית זו?',
+      confirmResetTitle: 'איפוס לברירות מחדל?',
+      confirmResetMessage: 'פעולה זו תשחזר את תבניות ברירת המחדל ותסיר את כל התבניות המותאמות אישית.',
+      confirmButton: 'אישור',
+      cancelButton: 'ביטול',
+      closeButton: 'סגור',
+      emptyState: 'אין תבניות עדיין',
+      saving: 'שומר...',
+    },
   },
   en: {
     appName: 'Maaser Tracker',
@@ -968,6 +988,26 @@ const translations = {
         columnMappingHelp: 'Select which column in your CSV corresponds to each field. Columns are auto-detected from headers.',
         externalCsvHelp: 'Your CSV appears to be from an external source (e.g., Google Sheets). We\'ll help you map the columns to import your data.',
       },
+    },
+
+    // Note Presets
+    presets: {
+      managePresetsTitle: 'Manage Presets',
+      addPresetPlaceholder: 'New preset...',
+      add: 'Add',
+      editPreset: 'Edit preset',
+      deletePreset: 'Delete preset',
+      defaultBadge: 'Default',
+      resetDefaults: 'Reset Defaults',
+      confirmDeleteTitle: 'Delete Preset?',
+      confirmDeleteMessage: 'Are you sure you want to delete this preset?',
+      confirmResetTitle: 'Reset to Defaults?',
+      confirmResetMessage: 'This will restore the default presets and remove all custom presets.',
+      confirmButton: 'Confirm',
+      cancelButton: 'Cancel',
+      closeButton: 'Close',
+      emptyState: 'No presets yet',
+      saving: 'Saving...',
     },
   },
 };

--- a/src/contexts/presets-translations.test.jsx
+++ b/src/contexts/presets-translations.test.jsx
@@ -1,0 +1,121 @@
+/**
+ * Tests: Preset Translations
+ *
+ * Verifies that the `presets` translation namespace is present
+ * in both `he` and `en` locales inside LanguageProvider.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { LanguageProvider } from '../contexts/LanguageProvider';
+import { useLanguage } from '../contexts/useLanguage';
+
+function makeWrapper(lang) {
+  // Override localStorage so LanguageProvider picks up the target language
+  localStorage.setItem('maaser-tracker-language', lang);
+
+  return function Wrapper({ children }) {
+    return <LanguageProvider>{children}</LanguageProvider>;
+  };
+}
+
+describe('Preset translations', () => {
+  describe('English (en)', () => {
+    it('should have presets namespace in en translations', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets).toBeDefined();
+    });
+
+    it('should have managePresetsTitle in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.managePresetsTitle).toBe('Manage Presets');
+    });
+
+    it('should have addPresetPlaceholder in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.addPresetPlaceholder).toBeDefined();
+    });
+
+    it('should have resetDefaults in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.resetDefaults).toBeDefined();
+    });
+
+    it('should have confirmDeleteMessage in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.confirmDeleteMessage).toBeDefined();
+    });
+
+    it('should have confirmResetMessage in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.confirmResetMessage).toBeDefined();
+    });
+
+    it('should have emptyState in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.emptyState).toBeDefined();
+    });
+
+    it('should have defaultBadge in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.defaultBadge).toBeDefined();
+    });
+
+    it('should have cancelButton in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.cancelButton).toBeDefined();
+    });
+
+    it('should have confirmButton in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.confirmButton).toBeDefined();
+    });
+
+    it('should have closeButton in en', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('en') });
+      expect(result.current.t.presets.closeButton).toBeDefined();
+    });
+  });
+
+  describe('Hebrew (he)', () => {
+    it('should have presets namespace in he translations', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets).toBeDefined();
+    });
+
+    it('should have managePresetsTitle in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.managePresetsTitle).toBe('ניהול תבניות');
+    });
+
+    it('should have resetDefaults in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.resetDefaults).toBeDefined();
+    });
+
+    it('should have confirmDeleteMessage in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.confirmDeleteMessage).toBeDefined();
+    });
+
+    it('should have emptyState in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.emptyState).toBeDefined();
+    });
+
+    it('should have cancelButton in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.cancelButton).toBeDefined();
+    });
+
+    it('should have confirmButton in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.confirmButton).toBeDefined();
+    });
+
+    it('should have closeButton in he', () => {
+      const { result } = renderHook(() => useLanguage(), { wrapper: makeWrapper('he') });
+      expect(result.current.t.presets.closeButton).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Closes #214

## Summary
Integrate note presets into the AddEntryForm and wire up all i18n translations for the notes/presets feature.

## Test Results
- **Tests:** 2284 passed, 0 failed, 1 skipped (62 test files)
- **New tests:** 39 tests added for form integration + translations
- **Lint:** 0 errors, 0 warnings
- **Commit:** 047abb7

## Checklist
- [x] Tests passing (2284/2284)
- [x] Lint clean (0 errors, 0 warnings)
- [x] Code review (syntax + security)
- [x] CI green